### PR TITLE
Frozen string issue fix.

### DIFF
--- a/lib/rambling/trie/stringifyable.rb
+++ b/lib/rambling/trie/stringifyable.rb
@@ -19,7 +19,7 @@ module Rambling
       # String representation of the current node.
       # @return [String] the string representation of the current node.
       def to_s
-        parent.to_s << letter.to_s
+        parent.to_s + letter.to_s
       end
     end
   end


### PR DESCRIPTION
Hello. 
In ruby 2.7.1 (latest stable for now) `#to_s` method for some singleton object (e.g. `nil`, `false`, `true`) returns frozen string.  `<<` modifies the receiver string and can't be used for frozen objects, so `nil.to_s << "hello" will throw an error. I replaced `<<` concatenation with simple `+`.