### PR TITLE
Rubocop: upgrade and apply

### DIFF
--- a/.rubocop.disabled.yml
+++ b/.rubocop.disabled.yml
@@ -38,16 +38,6 @@ Layout/MultilineAssignmentLayout:
 #   Description: 'Checks unsafe usage of number conversion methods.'
 #   Enabled: false
 
-# By default, the rails cops are not run. Override in project or home
-# directory .rubocop.yml files, or by giving the -R/--rails option.
-Rails:
-  Enabled: false
-
-Rails/SaveBang:
-  Description: 'Identifies possible cases where Active Record save! or related should be used.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#save-bang'
-  Enabled: false
-
 Style/AutoResourceCleanup:
   Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
   Enabled: false

--- a/.rubocop.enabled.yml
+++ b/.rubocop.enabled.yml
@@ -1,4 +1,8 @@
 # These are all the cops that are enabled in the default configuration.
+require:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
 
 #################### Bundler ###############################
 
@@ -58,20 +62,20 @@ Layout/AccessModifierIndentation:
   StyleGuide: '#indent-public-private-protected'
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
   StyleGuide: '#align-multiline-arrays'
   Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Description: >-
                  Align the elements of a hash literal if they span more than
                  one line.
   Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: >-
                  Align the parameters of a method call if they span more
                  than one line.
@@ -175,23 +179,23 @@ Layout/FirstParameterIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: true
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   Description: >-
                  Checks the indentation of the first element in an array
                  literal.
   Enabled: true
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Description: >-
                  Checks the indentation of the first line of the
                  right-hand-side of a multi-line assignment.
   Enabled: true
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Description: 'This cops checks the indentation of the here document bodies.'
   StyleGuide: '#squiggly-heredocs'
   Enabled: true
@@ -385,12 +389,12 @@ Layout/SpaceInsideStringInterpolation:
   StyleGuide: '#string-interpolation'
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Description: 'No hard tabs.'
   StyleGuide: '#spaces-indentation'
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: '#newline-eof'
   Enabled: true
@@ -432,7 +436,7 @@ Lint/AssignmentInCondition:
 #   Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
 #   Enabled: true
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
   Enabled: true
 
@@ -444,7 +448,7 @@ Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -455,7 +459,7 @@ Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
 
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
@@ -471,7 +475,7 @@ Lint/DuplicateMethods:
   Description: 'Check for duplicate method definitions.'
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Description: 'Check for duplicate keys in hash literals.'
   Enabled: true
 
@@ -500,12 +504,8 @@ Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
   Enabled: true
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Description: 'Align ends correctly.'
-  Enabled: true
-
-Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
   Enabled: true
 
 Lint/EnsureReturn:
@@ -523,7 +523,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
@@ -567,7 +567,7 @@ Lint/MissingCopEnableDirective:
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
   Enabled: true
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Description: "Use `&&` operator to compare multiple value."
   Enabled: true
 
@@ -674,13 +674,9 @@ Lint/ShadowingOuterLocalVariable:
                  for block arguments or block local variables.
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
   StyleGuide: '#no-to-s'
-  Enabled: true
-
-Lint/Syntax:
-  Description: 'Checks syntax error'
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -703,11 +699,11 @@ Lint/UnifiedInteger:
 #
 #   Enabled: true
 
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals'
   Enabled: true
 
@@ -750,7 +746,7 @@ Lint/UselessAssignment:
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Description: 'Checks for comparison of something with itself.'
   Enabled: true
 
@@ -794,7 +790,7 @@ Metrics/CyclomaticComplexity:
                  of test cases needed to validate a method.
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: '#80-character-limits'
   Enabled: true
@@ -923,8 +919,8 @@ Performance/Count:
   # This cop has known compatibility issues with `ActiveRecord` and other
   # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
   # For more information, see the documentation in the cop itself.
-  # If you understand the known risk, you can disable `SafeMode`.
-  SafeMode: true
+  # If you understand the known risk, you can disable `SafeAutoCorrect`.
+  SafeAutoCorrect: true
   Enabled: true
 
 Performance/Detect:
@@ -936,7 +932,7 @@ Performance/Detect:
   # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
   # has its own meaning. Correcting `ActiveRecord` methods with this cop
   # should be considered unsafe.
-  SafeMode: true
+  SafeAutoCorrect: true
   Enabled: true
 
 Performance/DoubleStartEndWith:
@@ -971,17 +967,13 @@ Performance/FlatMap:
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
 
-Performance/HashEachMethods:
+Style/HashEachMethods:
   Description: >-
                  Use `Hash#each_key` and `Hash#each_value` instead of
                  `Hash#keys.each` and `Hash#values.each`.
   StyleGuide: '#hash-each'
   Enabled: true
   AutoCorrect: false
-
-Performance/LstripRstrip:
-  Description: 'Use `strip` instead of `lstrip.rstrip`.'
-  Enabled: true
 
 Performance/RangeInclude:
   Description: 'Use `Range#cover?` instead of `Range#include?`.'
@@ -1004,7 +996,7 @@ Performance/RedundantMerge:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
 
-Performance/RedundantSortBy:
+Style/RedundantSortBy:
   Description: 'Use `sort` instead of `sort_by { |x| x }`.'
   Enabled: true
 
@@ -1019,7 +1011,7 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
-Performance/Sample:
+Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Integer]`.
@@ -1061,205 +1053,6 @@ Performance/UnfreezeString:
 
 Performance/UriDefaultParser:
   Description: 'Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.'
-  Enabled: true
-
-#################### Rails #################################
-
-Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
-  Enabled: true
-
-Rails/ActiveSupportAliases:
-  Description: >-
-                  Avoid ActiveSupport aliases of standard ruby methods:
-                  `String#starts_with?`, `String#ends_with?`,
-                  `Array#append`, `Array#prepend`.
-  Enabled: true
-
-Rails/ApplicationJob:
-  Description: 'Check that jobs subclass ApplicationJob.'
-  Enabled: true
-
-Rails/ApplicationRecord:
-  Description: 'Check that models subclass ApplicationRecord.'
-  Enabled: true
-
-Rails/Blank:
-  Description: 'Enforce using `blank?` and `present?`.'
-  Enabled: true
-  # Convert checks for `nil` or `empty?` to `blank?`
-  NilOrEmpty: true
-  # Convert usages of not `present?` to `blank?`
-  NotPresent: true
-  # Convert usages of `unless` `present?` to `if` `blank?`
-  UnlessPresent: true
-
-Rails/CreateTableWithTimestamps:
-  Description: >-
-                  Checks the migration for which timestamps are not included
-                  when creating a new table.
-  Enabled: true
-
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: true
-
-Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
-  Enabled: true
-
-Rails/DelegateAllowBlank:
-  Description: 'Do not use allow_blank as an option to delegate.'
-  Enabled: true
-
-Rails/DynamicFindBy:
-  Description: 'Use `find_by` instead of dynamic `find_by_*`.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#find_by'
-  Enabled: true
-
-Rails/EnumUniqueness:
-  Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
-  Enabled: true
-
-Rails/EnvironmentComparison:
-  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
-  Enabled: true
-
-Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
-  Enabled: true
-
-Rails/FilePath:
-  Description: 'Use `Rails.root.join` for file path joining.'
-  Enabled: true
-
-Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#find_by'
-  Enabled: true
-
-Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#find-each'
-  Enabled: true
-
-Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#has-many-through'
-  Enabled: true
-
-Rails/HasManyOrHasOneDependent:
-  Description: 'Define the dependent option to the has_many and has_one associations.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#has_many-has_one-dependent-option'
-  Enabled: true
-
-Rails/HttpPositionalArguments:
-  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
-  Enabled: true
-  Include:
-    - 'spec/**/*'
-    - 'test/**/*'
-
-Rails/InverseOf:
-  Description: 'Checks for associations where the inverse cannot be determined automatically.'
-  Enabled: true
-
-Rails/LexicallyScopedActionFilter:
-  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter'
-  Enabled: true
-
-Rails/NotNullColumn:
-  Description: 'Do not add a NOT NULL column without a default value'
-  Enabled: true
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
-
-Rails/OutputSafety:
-  Description: 'The use of `html_safe` or `raw` may be a security risk.'
-  Enabled: true
-
-Rails/PluralizationGrammar:
-  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
-  Enabled: true
-
-Rails/Presence:
-  Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
-  Enabled: true
-
-Rails/Present:
-  Description: 'Enforce using `blank?` and `present?`.'
-  Enabled: true
-  NotNilAndNotEmpty: true
-  # Convert checks for not `nil` and not `empty?` to `present?`
-  NotBlank: true
-  # Convert usages of not `blank?` to `present?`
-  UnlessBlank: true
-  # Convert usages of `unless` `blank?` to `if` `present?`
-
-Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#read-attribute'
-  Enabled: true
-
-Rails/RedundantReceiverInWithOptions:
-  Description: 'Checks for redundant receiver in `with_options`.'
-  Enabled: true
-
-Rails/RelativeDateConstant:
-  Description: 'Do not assign relative date to constants.'
-  Enabled: true
-
-Rails/RequestReferer:
-  Description: 'Use consistent syntax for request.referer.'
-  Enabled: true
-
-Rails/ReversibleMigration:
-  Description: 'Checks whether the change method of the migration file is reversible.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#reversible-migration'
-  Reference: 'http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
-  Enabled: true
-
-Rails/SafeNavigation:
-  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
-  Enabled: true
-
-Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
-  Enabled: true
-
-Rails/SkipsModelValidations:
-  Description: >-
-                 Use methods that skips model validations with caution.
-                 See reference for more information.
-  Reference: 'http://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
-  Enabled: true
-
-Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
-  Enabled: true
-
-Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq or distinct before pluck.'
-  Enabled: true
-
-Rails/UnknownEnv:
-  Description: 'Use correct environment name.'
-  Enabled: true
-
-Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
 
 #################### Security ##############################
@@ -1344,10 +1137,6 @@ Style/BlockDelimiters:
                 always ugly).
                 Prefer {...} over do...end for single-line blocks.
   StyleGuide: '#single-line-blocks'
-  Enabled: true
-
-Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
   Enabled: true
 
 Style/CaseEquality:
@@ -1497,7 +1286,7 @@ Style/EvenOdd:
 #   Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
 #   Enabled: true
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: '#no-flip-flops'
   Enabled: true
@@ -1607,7 +1396,12 @@ Style/MethodDefParentheses:
   StyleGuide: '#method-parens'
   Enabled: true
 
-Style/MethodMissing:
+Lint/MissingSuper:
+  Description: 'Avoid using `method_missing`.'
+  StyleGuide: '#no-method-missing'
+  Enabled: true
+
+Style/MissingRespondToMissing:
   Description: 'Avoid using `method_missing`.'
   StyleGuide: '#no-method-missing'
   Enabled: true
@@ -1975,15 +1769,15 @@ Style/UnlessElse:
   StyleGuide: '#no-else-with-unless'
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
   StyleGuide: '#percent-q'
   Enabled: true

--- a/.rubocop.enabled.yml
+++ b/.rubocop.enabled.yml
@@ -2,7 +2,7 @@
 require:
   - rubocop-performance
   - rubocop-rake
-  - rubocop-rspec
+  # - rubocop-rspec
 
 #################### Bundler ###############################
 

--- a/.rubocop.enabled.yml
+++ b/.rubocop.enabled.yml
@@ -2,7 +2,7 @@
 require:
   - rubocop-performance
   - rubocop-rake
-  # - rubocop-rspec
+  - rubocop-rspec
 
 #################### Bundler ###############################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1410,6 +1410,11 @@ Lint/UnusedMethodArgument:
 # Lint/Void:
 #   CheckForMethodsWithNoSideEffects: false
 
+#################### RSpec #################################
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
 #################### Performance ###########################
 
 Performance/DoubleStartEndWith:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Layout/AccessModifierIndentation:
   EnforcedStyle: indent
 
 # Align the elements of a hash literal if they span more than one line.
-Layout/AlignHash:
+Layout/HashAlignment:
   # Alignment of entries using colon as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -72,7 +72,7 @@ Layout/AlignHash:
   #       b: 2)
   EnforcedLastArgumentHashStyle: ignore_implicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   # Alignment of parameters in multi-line method calls.
   #
   # The `with_first_parameter` style aligns the following lines along the same
@@ -166,7 +166,7 @@ Layout/FirstParameterIndentation:
   #  # Same as `special_for_inner_method_call` except that the special rule only
   #  # applies if the outer method call encloses its arguments in parentheses.
   #  - special_for_inner_method_call_in_parentheses
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  EnforcedStyle: consistent
 
 Layout/IndentationConsistency:
   # The difference between `rails` and `normal` is that the `rails` style
@@ -183,7 +183,7 @@ Layout/IndentationWidth:
   IgnoredPatterns: []
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -205,13 +205,13 @@ Layout/IndentArray:
   IndentationWidth: ~
 
 # Checks the indentation of assignment RHS, when on a different line from LHS
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   # By default, the indentation width from `Layout/IndentationWidth` is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
 # Checks the indentation of the first key in a hash literal.
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
@@ -232,7 +232,7 @@ Layout/IndentHash:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   EnforcedStyle: auto_detection
   SupportedStyles:
     - auto_detection
@@ -427,14 +427,14 @@ Layout/ClassStructure:
       - protected_methods
       - private_methods
 
-Layout/Tab:
+Layout/IndentationStyle:
   # By default, the indentation width from Layout/IndentationWidth is used
   # But it can be overridden by setting this parameter
   # It is used during auto-correction to determine how many spaces should
   # replace each tab.
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -504,7 +504,7 @@ Naming/FileName:
     - XSS
 
 Naming/HeredocDelimiterNaming:
-  Blacklist:
+  ForbiddenDelimiters:
     - END
     - !ruby/regexp '/EO[A-Z]{1}/'
 
@@ -527,13 +527,13 @@ Naming/PredicateName:
     - has_
     - have_
   # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - has_
     - have_
   # Predicate names which, despite having a blacklisted prefix, or no `?`,
   # should still be accepted
-  NameWhitelist:
+  AllowedMethods:
     - is_a?
   # Method definition macros for dynamically generated methods.
   MethodDefinitionMacros:
@@ -548,20 +548,16 @@ Naming/PredicateName:
 #   # Parameter names may be equal to or greater than this value
 #   MinNameLength: 1
 #   AllowNamesEndingInNumbers: true
-#   # Whitelisted names that will not register an offense
 #   AllowedNames: []
-#   # Blacklisted names that will register an offense
 #   ForbiddenNames: []
 #
 # Naming/UncommunicativeMethodParamName:
 #   # Parameter names may be equal to or greater than this value
 #   MinNameLength: 3
 #   AllowNamesEndingInNumbers: true
-#   # Whitelisted names that will not register an offense
 #   AllowedNames:
 #     - io
 #     - id
-#   # Blacklisted names that will register an offense
 #   ForbiddenNames: []
 
 Naming/VariableName:
@@ -675,20 +671,6 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
 
 Style/ClassAndModuleChildren:
   # Checks the style of children definitions at classes and modules.
@@ -844,19 +826,7 @@ Style/FormatStringToken:
     - unannotated
 
 Style/FrozenStringLiteralComment:
-  EnforcedStyle: when_needed
-  SupportedStyles:
-    # `when_needed` will add the frozen string literal comment to files
-    # only when the `TargetRubyVersion` is set to 2.3+.
-    - when_needed
-    # `always` will always add the frozen string literal comment to a file
-    # regardless of the Ruby version or if `freeze` or `<<` are called on a
-    # string literal. If you run code against multiple versions of Ruby, it is
-    # possible that this will create errors in Ruby 2.3.0+.
-    - always
-    # `never` will enforce that the frozen string literal comment does not
-    # exist in a file.
-    - never
+  EnforcedStyle: always_true
 
 # Built-in global variables are allowed by default.
 Style/GlobalVars:
@@ -1188,7 +1158,18 @@ Style/TrailingCommaInArguments:
   # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+#   # SupportedStylesForMultiline:
+#   #   - comma
+#   #   - consistent_comma
+#   #   - no_comma
+#   # If `comma`, the cop requires a comma after the last item in an array,
+#   # but only when each item is on its own line.
+#   # If `consistent_comma`, the cop requires a comma after the last item of all
+#   # non-empty array literals.
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
 #   # SupportedStylesForMultiline:
 #   #   - comma
 #   #   - consistent_comma
@@ -1244,7 +1225,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c
@@ -1281,19 +1262,14 @@ Style/WordArray:
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
 Style/YodaCondition:
-  EnforcedStyle: all_comparison_operators
-  SupportedStyles:
-    # check all comparison operators
-    - all_comparison_operators
-    # check only equality operators: `!=` and `==`
-    - equality_operators_only
+  EnforcedStyle: require_for_all_comparison_operators
 
 #################### Metrics ###############################
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
-  Max: 15
+  Max: 20
   Exclude:
     - 'tasks/*.rb'
 
@@ -1320,7 +1296,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 6
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 80
   # To make it possible to copy or click on URIs in the code, we allow lines
   # containing a URI to be longer than Max.
@@ -1359,7 +1335,7 @@ Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
 # checks whether the end keywords are aligned properly for `do` `end` blocks.
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   # The value `start_of_block` means that the `end` should be aligned with line
   # where the `do` keyword appears.
   # The value `start_of_line` means it should be aligned with the whole
@@ -1367,7 +1343,7 @@ Lint/BlockAlignment:
   # The value `either` means both are allowed.
   EnforcedStyleAlignWith: start_of_line
 
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   # The value `def` means that `end` should be aligned with the def keyword.
   # The value `start_of_line` means that `end` should be aligned with method
   # calls like `private`, `public`, etc, if present in front of the `def`
@@ -1377,7 +1353,7 @@ Lint/DefEndAlignment:
   Severity: warning
 
 # Align ends correctly.
-Lint/EndAlignment:
+Layout/EndAlignment:
   # The value `keyword` means that `end` should be aligned with the matching
   # keyword (`if`, `while`, etc.).
   # The value `variable` means that in assignments, `end` should be aligned
@@ -1389,7 +1365,7 @@ Lint/EndAlignment:
   # AutoCorrect: false
   Severity: warning
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'spec/**/*'
 
@@ -1411,7 +1387,7 @@ Lint/MissingCopEnableDirective:
   MaximumRangeSize: .inf
 
 Lint/SafeNavigationChain:
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -1444,152 +1420,6 @@ Performance/DoubleStartEndWith:
 Performance/RedundantMerge:
   # Max number of key-value pairs to consider an offense
   MaxKeyValuePairs: 2
-
-#################### Rails #################################
-
-Rails/ActionFilter:
-  EnforcedStyle: action
-  SupportedStyles:
-    - action
-    - filter
-  Include:
-    - app/controllers/**/*.rb
-
-Rails/CreateTableWithTimestamps:
-  Include:
-    - db/migrate/*.rb
-
-Rails/Date:
-  # The value `strict` disallows usage of `Date.today`, `Date.current`,
-  # `Date#to_time` etc.
-  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
-  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
-  # time zone.
-  EnforcedStyle: flexible
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/Delegate:
-  # When set to true, using the target object as a prefix of the
-  # method name without using the `delegate` method will be a
-  # violation. When set to false, this case is legal.
-  EnforceForPrefixed: true
-
-Rails/DynamicFindBy:
-  Whitelist:
-    - find_by_sql
-
-Rails/EnumUniqueness:
-  Include:
-    - app/models/**/*.rb
-
-Rails/Exit:
-  Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - lib/**/*.rb
-  Exclude:
-    - lib/**/*.rake
-
-Rails/FindBy:
-  Include:
-    - app/models/**/*.rb
-
-Rails/FindEach:
-  Include:
-    - app/models/**/*.rb
-
-Rails/HasAndBelongsToMany:
-  Include:
-    - app/models/**/*.rb
-
-Rails/HasManyOrHasOneDependent:
-  Include:
-    - app/models/**/*.rb
-
-Rails/InverseOf:
-  Include:
-    - app/models/**/*.rb
-
-Rails/LexicallyScopedActionFilter:
-  Include:
-    - app/controllers/**/*.rb
-
-Rails/NotNullColumn:
-  Include:
-    - db/migrate/*.rb
-
-Rails/Output:
-  Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - db/**/*.rb
-    - lib/**/*.rb
-
-Rails/ReadWriteAttribute:
-  Include:
-    - app/models/**/*.rb
-
-Rails/RequestReferer:
-  EnforcedStyle: referer
-  SupportedStyles:
-    - referer
-    - referrer
-
-Rails/ReversibleMigration:
-  Include:
-    - db/migrate/*.rb
-
-Rails/SafeNavigation:
-  # This will convert usages of `try` to use safe navigation as well as `try!`.
-  # `try` and `try!` work slightly differently. `try!` and safe navigation will
-  # both raise a `NoMethodError` if the receiver of the method call does not
-  # implement the intended method. `try` will not raise an exception for this.
-  ConvertTry: false
-
-Rails/ScopeArgs:
-  Include:
-    - app/models/**/*.rb
-
-Rails/TimeZone:
-  # The value `strict` means that `Time` should be used with `zone`.
-  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
-  EnforcedStyle: flexible
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/UniqBeforePluck:
-  EnforcedStyle: conservative
-  SupportedStyles:
-    - conservative
-    - aggressive
-  AutoCorrect: false
-
-Rails/UnknownEnv:
-  Environments:
-    - development
-    - test
-    - production
-
-Rails/SkipsModelValidations:
-  Blacklist:
-    - decrement!
-    - decrement_counter
-    - increment!
-    - increment_counter
-    - toggle!
-    - touch
-    - update_all
-    - update_attribute
-    - update_column
-    - update_columns
-    - update_counters
-
-Rails/Validation:
-  Include:
-    - app/models/**/*.rb
 
 Bundler/OrderedGems:
   TreatCommentsAsGroupSeparators: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'pkg/**/*'
     - 'reports/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.5.0
+  TargetRubyVersion: 2.7.0
 
 #################### Layout ###########################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ AllCops:
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 # Align the elements of a hash literal if they span more than one line.
 Layout/HashAlignment:
   # Alignment of entries using colon as separator. Valid values are:
@@ -798,6 +801,10 @@ Style/EmptyMethod:
   SupportedStyles:
     - compact
     - expanded
+
+# Disable explicit block argument as it has a significant effect on performance
+Style/ExplicitBlockArgument:
+  Enabled: false
 
 # Checks use of for or each in multiline loops.
 Style/For:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1415,6 +1415,9 @@ Lint/UnusedMethodArgument:
 RSpec/MultipleMemoizedHelpers:
   Max: 10
 
+RSpec/NestedGroups:
+  Max: 5
+
 #################### Performance ###########################
 
 Performance/DoubleStartEndWith:

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ end
 
 group :test do
   gem 'coveralls_reborn', '~> 0.27.0', require: false
-  gem 'simplecov', require: false
   gem 'rspec_junit_formatter'
+  gem 'simplecov', require: false
 end
 
 group :local do

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,7 @@ end
 group :local do
   gem 'guard-rspec'
   gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rake', require: false
+  gem 'rubocop-rspec', require: false
 end

--- a/lib/rambling/trie/compressible.rb
+++ b/lib/rambling/trie/compressible.rb
@@ -9,7 +9,7 @@ module Rambling
       # @return [Boolean] `true` for non-{Nodes::Node#terminal? terminal} nodes
       #   with one child, `false` otherwise.
       def compressible?
-        !(root? || terminal?) && children_tree.size == 1
+        !(root? || terminal?) && 1 == children_tree.size
       end
     end
   end

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -59,6 +59,7 @@ module Rambling
       #   compressed.
       def compress
         return self if root.compressed?
+
         Rambling::Trie::Container.new compress_root, compressor
       end
 

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -51,9 +51,9 @@ module Rambling
         def first_child
           return if children_tree.empty?
 
-          children_tree.each_value do |child|
-            return child
-          end
+          # rubocop:disable Lint/UnreachableLoop
+          children_tree.each_value { |child| return child }
+          # rubocop:enable Lint/UnreachableLoop
         end
 
         # Indicates if the current node is the root node.

--- a/rambling-trie.gemspec
+++ b/rambling-trie.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'rambling/trie/version'
 
 Gem::Specification.new do |gem|

--- a/spec/integration/rambling/trie_spec.rb
+++ b/spec/integration/rambling/trie_spec.rb
@@ -8,30 +8,26 @@ describe Rambling::Trie do
 
   context 'when providing words directly' do
     it_behaves_like 'a compressible trie' do
-      let(:trie) { Rambling::Trie.create }
+      let(:trie) { described_class.create }
       let(:words) { %w(a couple of words for our full trie integration test) }
 
-      before do
-        trie.concat words
-      end
+      before { trie.concat words }
     end
   end
 
   context 'when provided with words with unicode characters' do
     it_behaves_like 'a compressible trie' do
-      let(:trie) { Rambling::Trie.create }
+      let(:trie) { described_class.create }
       let(:words) do
         %w(poquísimas palabras para nuestra prueba de integración completa 🙃)
       end
 
-      before do
-        trie.concat words
-      end
+      before { trie.concat words }
     end
   end
 
   context 'when provided with a filepath' do
-    let(:trie) { Rambling::Trie.create filepath }
+    let(:trie) { described_class.create filepath }
     let(:words) { File.readlines(filepath).map(&:chomp) }
 
     context 'with english words' do
@@ -53,33 +49,34 @@ describe Rambling::Trie do
 
     context 'when serialized with Ruby marshal format (default)' do
       it_behaves_like 'a serializable trie' do
-        let(:trie_to_serialize) { Rambling::Trie.create words_filepath }
+        let(:trie_to_serialize) { described_class.create words_filepath }
         let(:format) { :marshal }
       end
     end
 
     context 'when serialized with YAML' do
       it_behaves_like 'a serializable trie' do
-        let(:trie_to_serialize) { Rambling::Trie.create words_filepath }
+        let(:trie_to_serialize) { described_class.create words_filepath }
         let(:format) { :yml }
       end
     end
 
     context 'when serialized with zipped Ruby marshal format' do
+      let!(:original_on_exists_proc) { ::Zip.on_exists_proc }
+      let!(:original_continue_on_exists_proc) { ::Zip.continue_on_exists_proc }
+
       before do
-        @original_on_exists_proc = ::Zip.on_exists_proc
-        @original_continue_on_exists_proc = ::Zip.continue_on_exists_proc
         ::Zip.on_exists_proc = true
         ::Zip.continue_on_exists_proc = true
       end
 
       after do
-        ::Zip.on_exists_proc = @original_on_exists_proc
-        ::Zip.continue_on_exists_proc = @original_continue_on_exists_proc
+        ::Zip.on_exists_proc = original_on_exists_proc
+        ::Zip.continue_on_exists_proc = original_continue_on_exists_proc
       end
 
       it_behaves_like 'a serializable trie' do
-        let(:trie_to_serialize) { Rambling::Trie.create words_filepath }
+        let(:trie_to_serialize) { described_class.create words_filepath }
         let(:format) { 'marshal.zip' }
       end
     end

--- a/spec/lib/rambling/trie/comparable_spec.rb
+++ b/spec/lib/rambling/trie/comparable_spec.rb
@@ -4,93 +4,83 @@ require 'spec_helper'
 
 describe Rambling::Trie::Comparable do
   describe '#==' do
-    let(:node_1) { Rambling::Trie::Nodes::Raw.new }
-    let(:node_2) { Rambling::Trie::Nodes::Raw.new }
+    let(:node_one) { Rambling::Trie::Nodes::Raw.new }
+    let(:node_two) { Rambling::Trie::Nodes::Raw.new }
 
     context 'when the nodes do not have the same letter' do
       before do
-        node_1.letter = :a
-        node_2.letter = :b
+        node_one.letter = :a
+        node_two.letter = :b
       end
 
       it 'returns false' do
-        expect(node_1).not_to eq node_2
+        expect(node_one).not_to eq node_two
       end
     end
 
-    context 'when the nodes have the same letter and no children' do
+    context 'when nodes have same letter, not terminal and no children' do
       before do
-        node_1.letter = :a
-        node_2.letter = :a
+        node_one.letter = :a
+        node_two.letter = :a
       end
 
       it 'returns true' do
-        expect(node_1).to eq node_2
+        expect(node_one).to eq node_two
       end
     end
 
     context 'when the nodes have the same letter and are terminal' do
       before do
-        node_1.letter = :a
-        node_1.terminal!
+        node_one.letter = :a
+        node_one.terminal!
 
-        node_2.letter = :a
-        node_2.terminal!
+        node_two.letter = :a
+        node_two.terminal!
       end
 
       it 'returns true' do
-        expect(node_1).to eq node_2
-      end
-    end
-
-    context 'when the nodes have the same letter and are not terminal' do
-      before do
-        node_1.letter = :a
-        node_2.letter = :a
-      end
-
-      it 'returns true' do
-        expect(node_1).to eq node_2
+        expect(node_one).to eq node_two
       end
     end
 
     context 'when the nodes have the same letter but are not both terminal' do
       before do
-        node_1.letter = :a
-        node_1.terminal!
+        node_one.letter = :a
+        node_one.terminal!
 
-        node_2.letter = :a
+        node_two.letter = :a
       end
+
       it 'returns false' do
-        expect(node_1).not_to eq node_2
+        expect(node_one).not_to eq node_two
       end
     end
 
     context 'when the nodes have the same letter and the same children' do
       before do
-        node_1.letter = :t
-        add_words node_1, %w(hese hree hings)
+        node_one.letter = :t
+        add_words node_one, %w(hese hree hings)
 
-        node_2.letter = :t
-        add_words node_2, %w(hese hree hings)
+        node_two.letter = :t
+        add_words node_two, %w(hese hree hings)
       end
 
       it 'returns true' do
-        expect(node_1).to eq node_2
+        expect(node_one).to eq node_two
       end
     end
 
     context 'when the nodes have the same letter but different children' do
       before do
-        node_1.letter = :t
-        add_words node_1, %w(hese wo)
+        node_one.letter = :t
+        add_words node_one, %w(hese wo)
 
-        node_2.letter = :t
-        add_words node_2, %w(hese hree hings)
+        node_two.letter = :t
+        add_words node_two, %w(hese hree hings)
       end
 
       it 'returns false' do
-        expect(node_1).not_to eq node_2
+        expect(node_one).not_to eq node_two
       end
     end
   end

--- a/spec/lib/rambling/trie/compressor_spec.rb
+++ b/spec/lib/rambling/trie/compressor_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Compressor do
-  let(:compressor) { Rambling::Trie::Compressor.new }
+  let(:compressor) { described_class.new }
 
   describe '#compress' do
     let(:node) { Rambling::Trie::Nodes::Raw.new }
@@ -16,9 +16,7 @@ describe Rambling::Trie::Compressor do
     end
 
     context 'with at least one word' do
-      before do
-        add_words node, %w(all the words)
-      end
+      before { add_words node, %w(all the words) }
 
       it 'keeps the node letter nil' do
         compressed = compressor.compress node
@@ -28,25 +26,25 @@ describe Rambling::Trie::Compressor do
     end
 
     context 'with a single word' do
-      before do
-        add_word node, 'all'
-      end
+      before { add_word node, 'all' }
 
+      # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       it 'compresses into a single node without children' do
         compressed = compressor.compress node
+        compressed_node_a = compressed[:a]
 
-        expect(compressed[:a].letter).to eq :all
-        expect(compressed[:a].children.size).to eq 0
-        expect(compressed[:a]).to be_terminal
-        expect(compressed[:a]).to be_compressed
+        expect(compressed_node_a.letter).to eq :all
+        expect(compressed_node_a.children.size).to eq 0
+        expect(compressed_node_a).to be_terminal
+        expect(compressed_node_a).to be_compressed
       end
+      # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
     end
 
     context 'with two words' do
-      before do
-        add_words node, %w(all ask)
-      end
+      before { add_words node, %w(all ask) }
 
+      # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       it 'compresses into corresponding three nodes' do
         compressed = compressor.compress node
 
@@ -65,8 +63,10 @@ describe Rambling::Trie::Compressor do
         expect(compressed[:a][:l]).to be_compressed
         expect(compressed[:a][:s]).to be_compressed
       end
+      # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
     end
 
+    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
     it 'reassigns the parent nodes correctly' do
       add_words node, %w(repay rest repaint)
       compressed = compressor.compress node
@@ -91,7 +91,9 @@ describe Rambling::Trie::Compressor do
       expect(compressed[:r][:p][:i].parent).to eq compressed[:r][:p]
       expect(compressed[:r][:p][:i].children.size).to eq 0
     end
+    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
 
+    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
     it 'does not compress terminal nodes' do
       add_words node, %w(you your yours)
       compressed = compressor.compress node
@@ -104,5 +106,6 @@ describe Rambling::Trie::Compressor do
       expect(compressed[:y][:r][:s].letter).to eq :s
       expect(compressed[:y][:r][:s]).to be_compressed
     end
+    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
   end
 end

--- a/spec/lib/rambling/trie/configuration/properties_spec.rb
+++ b/spec/lib/rambling/trie/configuration/properties_spec.rb
@@ -3,13 +3,17 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Configuration::Properties do
-  let(:properties) { Rambling::Trie::Configuration::Properties.new }
+  let(:properties) { described_class.new }
 
   describe '.new' do
-    it 'configures the serializers' do
+    it 'configures the serializer formats' do
       serializers = properties.serializers
-
       expect(serializers.formats).to match_array %i(marshal yaml yml zip)
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'configures the serializer providers' do
+      serializers = properties.serializers
       expect(serializers.providers.to_a).to match_array [
         [:marshal, Rambling::Trie::Serializers::Marshal],
         [:yaml, Rambling::Trie::Serializers::Yaml],
@@ -17,11 +21,15 @@ describe Rambling::Trie::Configuration::Properties do
         [:zip, Rambling::Trie::Serializers::Zip],
       ]
     end
+    # rubocop:enable RSpec/ExampleLength
 
-    it 'configures the readers' do
+    it 'configures the reader formats' do
       readers = properties.readers
-
       expect(readers.formats).to match_array %i(txt)
+    end
+
+    it 'configures the reader providers' do
+      readers = properties.readers
       expect(readers.providers.to_a).to match_array [
         [:txt, Rambling::Trie::Readers::PlainText],
       ]
@@ -44,14 +52,24 @@ describe Rambling::Trie::Configuration::Properties do
       properties.readers.add :test, 'test'
     end
 
-    it 'resets the serializers and readers to initial values' do
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'resets the serializers to initial values' do
       expect(properties.serializers.formats).to include :test
-      expect(properties.readers.formats).to include :test
 
       properties.reset
 
       expect(properties.serializers.formats).not_to include :test
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'resets the readers to initial values' do
+      expect(properties.readers.formats).to include :test
+
+      properties.reset
+
       expect(properties.readers.formats).not_to include :test
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -170,133 +170,64 @@ describe Rambling::Trie::Container do
   end
 
   describe '#word?' do
-    [
-      [true, 'Rambling::Trie::Nodes::Compressed'],
-      [false, 'Rambling::Trie::Nodes::Raw'],
-    ].each do |test_params|
-      compressed_value, instance_double_class = test_params
-
-      context "when root has compressed=#{compressed_value}" do
-        let(:root) do
-          instance_double(
-            instance_double_class,
-            :root,
-            compressed?: compressed_value,
-            word?: nil,
-          )
-        end
-
-        it 'calls the root with the word characters' do
-          container.word? 'words'
-          expect(root).to have_received(:word?).with %w(w o r d s)
-        end
-      end
+    it_behaves_like 'a propagating node' do
+      let(:method) { :word? }
     end
 
     context 'when word is contained' do
       before { add_words container, %w(hello high) }
 
-      %w(hello high).each do |word|
-        it 'matches the whole word' do
-          expect(container.word? word).to be true
-        end
-      end
+      it_behaves_like 'a matching container#word'
 
       context 'with compressed root' do
         before { container.compress! }
 
-        %w(hello high).each do |word|
-          it 'matches the whole word' do
-            expect(container.word? word).to be true
-          end
-        end
+        it_behaves_like 'a matching container#word'
       end
     end
 
     context 'when word is not contained' do
       before { add_word container, 'hello' }
 
-      %w(halt al).each do |word|
-        it 'does not match the whole word' do
-          expect(container.word? word).to be false
-        end
-      end
+      it_behaves_like 'a non-matching container#word'
 
       context 'with compressed root' do
         before { container.compress! }
 
-        %w(halt al).each do |word|
-          it 'does not match the whole word' do
-            expect(container.word? word).to be false
-          end
-        end
+        it_behaves_like 'a non-matching container#word'
       end
     end
   end
 
   describe '#partial_word?' do
-    [
-      [true, 'Rambling::Trie::Nodes::Compressed'],
-      [false, 'Rambling::Trie::Nodes::Raw'],
-    ].each do |test_params|
-      compressed_value, instance_double_class = test_params
+    context 'with underlying node' do
 
-      context "when root has compressed=#{compressed_value}" do
-        let(:root) do
-          instance_double(
-            instance_double_class,
-            :root,
-            compressed?: compressed_value,
-            partial_word?: nil,
-          )
-        end
-
-        it 'calls the root with the word characters' do
-          container.partial_word? 'words'
-          expect(root).to have_received(:partial_word?).with %w(w o r d s)
-        end
+      it_behaves_like 'a propagating node' do
+        let(:method) { :partial_word? }
       end
     end
 
     context 'when word is contained' do
       before { add_words container, %w(hello high) }
 
-      %w(h he hell hello hi hig high).each do |prefix|
-        it 'matches part of the word' do
-          expect(container.partial_word? prefix).to be true
-        end
-      end
+      it_behaves_like 'a matching container#partial_word'
 
       context 'with compressed root' do
         before { container.compress! }
 
-        %w(h he hell hello hi hig high).each do |prefix|
-          it 'matches part of the word' do
-            expect(container.partial_word? prefix).to be true
-          end
-        end
-      end
-    end
-
-    shared_examples_for 'a non matching tree' do
-      it 'does not match any part of the word' do
-        %w(ha hal al).each do |word|
-          expect(container.partial_word? word).to be false
-        end
+        it_behaves_like 'a matching container#partial_word'
       end
     end
 
     context 'when word is not contained' do
       before { add_word container, 'hello' }
 
-      context 'with uncompressed root' do
-        it_behaves_like 'a non matching tree'
-      end
+      it_behaves_like 'a non-matching container#partial_word'
 
       context 'with compressed root' do
         before { container.compress! }
 
-        it_behaves_like 'a non matching tree'
+        it_behaves_like 'a non-matching container#partial_word'
       end
     end
   end
@@ -307,30 +238,12 @@ describe Rambling::Trie::Container do
         add_words container, %w(hi hello high hell highlight histerical)
       end
 
-      [
-        ['hi', %w(hi high highlight histerical)],
-        ['hig', %w(high highlight)],
-      ].each do |test_params|
-        prefix, expected = test_params
-
-        it "returns an array with the words that match '#{prefix}'" do
-          expect(container.scan prefix).to eq expected
-        end
-      end
+      it_behaves_like 'a matching container#scan'
 
       context 'with compressed root' do
         before { container.compress! }
 
-        [
-          ['hi', %w(hi high highlight histerical)],
-          ['hig', %w(high highlight)],
-        ].each do |test_params|
-          prefix, expected = test_params
-
-          it "returns an array with the words that match '#{prefix}'" do
-            expect(container.scan prefix).to eq expected
-          end
-        end
+        it_behaves_like 'a matching container#scan'
       end
     end
 
@@ -369,30 +282,12 @@ describe Rambling::Trie::Container do
     end
 
     context 'when phrase contains one word at the start of the phrase' do
-      [
-        ['word', %w(word)],
-        ['wordxyz', %w(word)],
-      ].each do |test_params|
-        phrase, expected = test_params
-
-        it "returns an array with the word found in the phrase '#{phrase}'" do
-          expect(container.words_within phrase).to match_array expected
-        end
-      end
+      it_behaves_like 'a matching container#words_within'
 
       context 'with compressed node' do
         before { container.compress! }
 
-        [
-          ['word', %w(word)],
-          ['wordxyz', %w(word)],
-        ].each do |test_params|
-          phrase, expected = test_params
-
-          it "returns an array with the word found in the phrase '#{phrase}'" do
-            expect(container.words_within phrase).to match_array expected
-          end
-        end
+        it_behaves_like 'a matching container#words_within'
       end
     end
 
@@ -411,18 +306,12 @@ describe Rambling::Trie::Container do
     end
 
     context 'when phrase contains a few words' do
-      it 'returns an array with all words found in the phrase' do
-        expect(container.words_within 'xyzword otherzxyone')
-          .to match_array %w(word other one)
-      end
+      it_behaves_like 'a non-matching container#words_within'
 
       context 'with compressed node' do
         before { container.compress! }
 
-        it 'returns an array with all words found in the phrase' do
-          expect(container.words_within 'xyzword otherzxyone')
-            .to match_array %w(word other one)
-        end
+        it_behaves_like 'a non-matching container#words_within'
       end
     end
   end
@@ -430,18 +319,12 @@ describe Rambling::Trie::Container do
   describe '#words_within?' do
     before { add_words container, %w(one word and other words) }
 
-    context 'when phrase does not contain any words' do
-      it 'returns false' do
-        expect(container.words_within? 'xyz').to be false
-      end
-    end
+    it_behaves_like 'a matching container#words_within?'
 
-    context 'when phrase contains any word' do
-      ['xyz words', 'xyzone word'].each do |phrase|
-        it "returns true for '#{phrase}'" do
-          expect(container.words_within? phrase).to be true
-        end
-      end
+    context 'with compressed node' do
+        before { container.compress! }
+
+        it_behaves_like 'a matching container#words_within?'
     end
   end
 

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Container do
-  let(:container) { Rambling::Trie::Container.new root, compressor }
+  subject(:container) { described_class.new root, compressor }
+
   let(:compressor) { Rambling::Trie::Compressor.new }
   let(:root) { Rambling::Trie::Nodes::Raw.new }
 
@@ -16,7 +17,7 @@ describe Rambling::Trie::Container do
       it 'yields the container' do
         yielded = nil
 
-        container = Rambling::Trie::Container.new root, compressor do |c|
+        container = described_class.new root, compressor do |c|
           yielded = c
         end
 
@@ -26,15 +27,18 @@ describe Rambling::Trie::Container do
   end
 
   describe '#add' do
+    # rubocop:disable RSpec/MultipleExpectations
     it 'adds the word to the root node' do
       add_word container, 'hello'
 
       expect(root.children.size).to eq 1
       expect(root.to_a).to eq %w(hello)
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe '#concat' do
+    # rubocop:disable RSpec/MultipleExpectations
     it 'adds all the words to the root node' do
       container.concat %w(other words)
 
@@ -48,42 +52,7 @@ describe Rambling::Trie::Container do
       expect(nodes.first.letter).to eq :o
       expect(nodes.last.letter).to eq :w
     end
-  end
-
-  describe '#compress!' do
-    let(:node) { Rambling::Trie::Nodes::Compressed.new }
-
-    before do
-      allow(compressor).to receive(:compress).and_return node
-
-      add_word root, 'yes'
-      node[:yes] = Rambling::Trie::Nodes::Compressed.new
-    end
-
-    it 'compresses the trie using the compressor' do
-      container.compress!
-
-      expect(compressor).to have_received(:compress).with root
-    end
-
-    it 'changes to the root returned by the compressor' do
-      container.compress!
-
-      expect(container.root).not_to eq root
-      expect(container.root).to eq node
-    end
-
-    it 'returns itself' do
-      expect(container.compress!).to eq container
-    end
-
-    it 'does not compress multiple times' do
-      container.compress!
-      allow(node).to receive(:compressed?).and_return(true)
-
-      container.compress!
-      expect(compressor).to have_received(:compress).once
-    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe '#compress' do
@@ -102,12 +71,14 @@ describe Rambling::Trie::Container do
       expect(compressor).to have_received(:compress).with root
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'returns a container with the new root' do
       new_container = container.compress
 
       expect(new_container.root).not_to eq root
       expect(new_container.root).to eq node
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it 'returns a new container' do
       expect(container.compress).not_to eq container
@@ -128,55 +99,400 @@ describe Rambling::Trie::Container do
     end
   end
 
-  describe '#word?' do
-    let(:root) do
-      double :root,
-        compressed?: compressed,
-        word?: nil
+  describe '#compress!' do
+    let(:node) { Rambling::Trie::Nodes::Compressed.new }
+
+    context 'with a mocked result' do
+      before do
+        allow(compressor).to receive(:compress).and_return node
+
+        add_word root, 'yes'
+        node[:yes] = Rambling::Trie::Nodes::Compressed.new
+      end
+
+      it 'compresses the trie using the compressor' do
+        container.compress!
+
+        expect(compressor).to have_received(:compress).with root
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'changes to the root returned by the compressor' do
+        container.compress!
+
+        expect(container.root).not_to eq root
+        expect(container.root).to eq node
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      it 'returns itself' do
+        expect(container.compress!).to eq container
+      end
+
+      it 'does not compress multiple times' do
+        container.compress!
+        allow(node).to receive(:compressed?).and_return(true)
+
+        container.compress!
+        expect(compressor).to have_received(:compress).once
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'gets a new root from the compressor' do
+        container.compress!
+
+        expect(container.root).not_to be root
+        expect(container.root).to be_compressed
+        expect(root).not_to be_compressed
+      end
+      # rubocop:enable RSpec/MultipleExpectations
     end
 
-    context 'for an uncompressed root' do
-      let(:compressed) { true }
+    it 'generates a new root with the words from the passed root' do
+      words = %w(a few words hello hell)
 
-      it 'calls the root with the word characters' do
-        container.word? 'words'
-        expect(root).to have_received(:word?).with %w(w o r d s)
+      add_words container, words
+      container.compress!
+
+      words.each { |word| expect(container).to include word }
+    end
+
+    describe 'and trying to add a word' do
+      it 'raises an error' do
+        add_words container, %w(repay rest repaint)
+        container.compress!
+
+        expect do
+          add_word container, 'restaurant'
+        end.to raise_error Rambling::Trie::InvalidOperation
+      end
+    end
+  end
+
+  describe '#word?' do
+    [
+      [true, 'Rambling::Trie::Nodes::Compressed'],
+      [false, 'Rambling::Trie::Nodes::Raw'],
+    ].each do |test_params|
+      compressed_value, instance_double_class = test_params
+
+      context "when root has compressed=#{compressed_value}" do
+        let(:root) do
+          instance_double(
+            instance_double_class,
+            :root,
+            compressed?: compressed_value,
+            word?: nil,
+          )
+        end
+
+        it 'calls the root with the word characters' do
+          container.word? 'words'
+          expect(root).to have_received(:word?).with %w(w o r d s)
+        end
       end
     end
 
-    context 'for a compressed root' do
-      let(:compressed) { false }
+    context 'when word is contained' do
+      before { add_words container, %w(hello high) }
 
-      it 'calls the root with the full word' do
-        container.word? 'words'
-        expect(root).to have_received(:word?).with %w(w o r d s)
+      %w(hello high).each do |word|
+        it 'matches the whole word' do
+          expect(container.word? word).to be true
+        end
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        %w(hello high).each do |word|
+          it 'matches the whole word' do
+            expect(container.word? word).to be true
+          end
+        end
+      end
+    end
+
+    context 'when word is not contained' do
+      before { add_word container, 'hello' }
+
+      %w(halt al).each do |word|
+        it 'does not match the whole word' do
+          expect(container.word? word).to be false
+        end
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        %w(halt al).each do |word|
+          it 'does not match the whole word' do
+            expect(container.word? word).to be false
+          end
+        end
       end
     end
   end
 
   describe '#partial_word?' do
-    let(:root) do
-      double :root,
-        compressed?: compressed,
-        partial_word?: nil
-    end
+    [
+      [true, 'Rambling::Trie::Nodes::Compressed'],
+      [false, 'Rambling::Trie::Nodes::Raw'],
+    ].each do |test_params|
+      compressed_value, instance_double_class = test_params
 
-    context 'for an uncompressed root' do
-      let(:compressed) { true }
+      context "when root has compressed=#{compressed_value}" do
+        let(:root) do
+          instance_double(
+            instance_double_class,
+            :root,
+            compressed?: compressed_value,
+            partial_word?: nil,
+          )
+        end
 
-      it 'calls the root with the word characters' do
-        container.partial_word? 'words'
-        expect(root).to have_received(:partial_word?).with %w(w o r d s)
+        it 'calls the root with the word characters' do
+          container.partial_word? 'words'
+          expect(root).to have_received(:partial_word?).with %w(w o r d s)
+        end
       end
     end
 
-    context 'for a compressed root' do
-      let(:compressed) { false }
+    context 'when word is contained' do
+      before { add_words container, %w(hello high) }
 
-      it 'calls the root with the word characters' do
-        container.partial_word? 'words'
-        expect(root).to have_received(:partial_word?).with %w(w o r d s)
+      %w(h he hell hello hi hig high).each do |prefix|
+        it 'matches part of the word' do
+          expect(container.partial_word? prefix).to be true
+        end
       end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        %w(h he hell hello hi hig high).each do |prefix|
+          it 'matches part of the word' do
+            expect(container.partial_word? prefix).to be true
+          end
+        end
+      end
+    end
+
+    shared_examples_for 'a non matching tree' do
+      it 'does not match any part of the word' do
+        %w(ha hal al).each do |word|
+          expect(container.partial_word? word).to be false
+        end
+      end
+    end
+
+    context 'when word is not contained' do
+      before { add_word container, 'hello' }
+
+      # rubocop:disable RSpec/RepeatedExampleGroupBody
+      context 'with uncompressed root' do
+        it_behaves_like 'a non matching tree'
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        it_behaves_like 'a non matching tree'
+      end
+      # rubocop:enable RSpec/RepeatedExampleGroupBody
+    end
+  end
+
+  describe '#scan' do
+    context 'when words that match are contained' do
+      before do
+        add_words container, %w(hi hello high hell highlight histerical)
+      end
+
+      [
+        ['hi', %w(hi high highlight histerical)],
+        ['hig', %w(high highlight)],
+      ].each do |test_params|
+        prefix, expected = test_params
+
+        it "returns an array with the words that match '#{prefix}'" do
+          expect(container.scan prefix).to eq expected
+        end
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        [
+          ['hi', %w(hi high highlight histerical)],
+          ['hig', %w(high highlight)],
+        ].each do |test_params|
+          prefix, expected = test_params
+
+          it "returns an array with the words that match '#{prefix}'" do
+            expect(container.scan prefix).to eq expected
+          end
+        end
+      end
+    end
+
+    context 'when words that match are not contained' do
+      before { add_word container, 'hello' }
+
+      it 'returns an empty array' do
+        expect(container.scan 'hi').to eq %w()
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        it 'returns an empty array' do
+          expect(container.scan 'hi').to eq %w()
+        end
+      end
+    end
+  end
+
+  describe '#words_within' do
+    before { add_words container, %w(one word and other words) }
+
+    context 'when phrase does not contain any words' do
+      it 'returns an empty array' do
+        expect(container.words_within 'xyz').to match_array []
+      end
+
+      context 'with compressed node' do
+        before { container.compress! }
+
+        it 'returns an empty array' do
+          expect(container.words_within 'xyz').to match_array []
+        end
+      end
+    end
+
+    context 'when phrase contains one word at the start of the phrase' do
+      [
+        ['word', %w(word)],
+        ['wordxyz', %w(word)],
+      ].each do |test_params|
+        phrase, expected = test_params
+
+        it "returns an array with the word found in the phrase '#{phrase}'" do
+          expect(container.words_within phrase).to match_array expected
+        end
+      end
+
+      context 'with compressed node' do
+        before { container.compress! }
+
+        [
+          ['word', %w(word)],
+          ['wordxyz', %w(word)],
+        ].each do |test_params|
+          phrase, expected = test_params
+
+          it "returns an array with the word found in the phrase '#{phrase}'" do
+            expect(container.words_within phrase).to match_array expected
+          end
+        end
+      end
+    end
+
+    context 'when phrase contains one word at the end of the phrase' do
+      it 'returns an array with the word found in the phrase' do
+        expect(container.words_within 'xyz word').to match_array %w(word)
+      end
+
+      context 'with compressed node' do
+        before { container.compress! }
+
+        it 'returns an array with the word found in the phrase' do
+          expect(container.words_within 'xyz word').to match_array %w(word)
+        end
+      end
+    end
+
+    context 'when phrase contains a few words' do
+      it 'returns an array with all words found in the phrase' do
+        expect(container.words_within 'xyzword otherzxyone')
+          .to match_array %w(word other one)
+      end
+
+      context 'with compressed node' do
+        before { container.compress! }
+
+        it 'returns an array with all words found in the phrase' do
+          expect(container.words_within 'xyzword otherzxyone')
+            .to match_array %w(word other one)
+        end
+      end
+    end
+  end
+
+  describe '#words_within?' do
+    before { add_words container, %w(one word and other words) }
+
+    context 'when phrase does not contain any words' do
+      it 'returns false' do
+        expect(container.words_within? 'xyz').to be false
+      end
+    end
+
+    context 'when phrase contains any word' do
+      ['xyz words', 'xyzone word'].each do |phrase|
+        it "returns true for '#{phrase}'" do
+          expect(container.words_within? phrase).to be true
+        end
+      end
+    end
+  end
+
+  describe '#==' do
+    context 'when the root nodes are the same' do
+      let(:other_container) do
+        described_class.new container.root, compressor
+      end
+
+      it 'returns true' do
+        expect(container).to eq other_container
+      end
+    end
+
+    context 'when the root nodes are not the same' do
+      let(:other_root) { Rambling::Trie::Nodes::Raw.new }
+      let(:other_container) do
+        described_class.new other_root, compressor
+      end
+
+      before { add_word other_container, 'hola' }
+
+      it 'returns false' do
+        expect(container).not_to eq other_container
+      end
+    end
+  end
+
+  describe '#each' do
+    before { add_words container, %w(yes no why) }
+
+    it 'returns an enumerator when no block is given' do
+      expect(container.each).to be_instance_of Enumerator
+    end
+
+    it 'iterates through all words contained' do
+      expect(container.each.to_a).to eq %w(yes no why)
+    end
+  end
+
+  describe '#inspect' do
+    before { add_words container, %w(a few words hello hell) }
+
+    it 'returns the container class name plus the root inspection' do
+      expect(container.inspect).to eq one_line <<~CONTAINER
+        #<Rambling::Trie::Container root: #<Rambling::Trie::Nodes::Raw letter: nil,
+        terminal: nil,
+        children: [:a, :f, :w, :h]>>
+      CONTAINER
     end
   end
 
@@ -265,329 +581,6 @@ describe Rambling::Trie::Container do
     it 'delegates `#size` to the root node' do
       container.size
       expect(root).to have_received :size
-    end
-  end
-
-  describe '#compress!' do
-    it 'gets a new root from the compressor' do
-      container.compress!
-
-      expect(container.root).not_to be root
-      expect(container.root).to be_compressed
-      expect(root).not_to be_compressed
-    end
-
-    it 'generates a new root with the words from the passed root' do
-      words = %w(a few words hello hell)
-
-      add_words container, words
-      container.compress!
-
-      words.each do |word|
-        expect(container).to include word
-      end
-    end
-
-    describe 'and trying to add a word' do
-      it 'raises an error' do
-        add_words container, %w(repay rest repaint)
-        container.compress!
-
-        expect do
-          add_word container, 'restaurant'
-        end.to raise_error Rambling::Trie::InvalidOperation
-      end
-    end
-  end
-
-  describe '#word?' do
-    context 'word is contained' do
-      before do
-        add_words container, %w(hello high)
-      end
-
-      it 'matches the whole word' do
-        expect(container.word? 'hello').to be true
-        expect(container.word? 'high').to be true
-      end
-
-      context 'and the root has been compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'matches the whole word' do
-          expect(container.word? 'hello').to be true
-          expect(container.word? 'high').to be true
-        end
-      end
-    end
-
-    context 'word is not contained' do
-      before do
-        add_word container, 'hello'
-      end
-
-      it 'does not match the whole word' do
-        expect(container.word? 'halt').to be false
-        expect(container.word? 'al').to be false
-      end
-
-      context 'and the root has been compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'does not match the whole word' do
-          expect(container.word? 'halt').to be false
-          expect(container.word? 'al').to be false
-        end
-      end
-    end
-  end
-
-  describe '#partial_word?' do
-    context 'word is contained' do
-      before do
-        add_words container, %w(hello high)
-      end
-
-      it 'matches part of the word' do
-        expect(container.partial_word? 'hell').to be true
-        expect(container.partial_word? 'hig').to be true
-      end
-
-      context 'and the root has been compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'matches part of the word' do
-          expect(container.partial_word? 'h').to be true
-          expect(container.partial_word? 'he').to be true
-          expect(container.partial_word? 'hell').to be true
-          expect(container.partial_word? 'hello').to be true
-          expect(container.partial_word? 'hi').to be true
-          expect(container.partial_word? 'hig').to be true
-          expect(container.partial_word? 'high').to be true
-        end
-      end
-    end
-
-    shared_examples_for 'a non matching tree' do
-      it 'does not match any part of the word' do
-        %w(ha hal al).each do |word|
-          expect(container.partial_word? word).to be false
-        end
-      end
-    end
-
-    context 'word is not contained' do
-      before do
-        add_word container, 'hello'
-      end
-
-      context 'and the root is uncompressed' do
-        it_behaves_like 'a non matching tree'
-      end
-
-      context 'and the root has been compressed' do
-        before { container.compress! }
-
-        it_behaves_like 'a non matching tree'
-      end
-    end
-  end
-
-  describe '#scan' do
-    context 'words that match are not contained' do
-      before do
-        add_words container, %w(hi hello high hell highlight histerical)
-      end
-
-      it 'returns an array with the words that match' do
-        expect(container.scan 'hi').to eq %w(hi high highlight histerical)
-        expect(container.scan 'hig').to eq %w(high highlight)
-      end
-
-      context 'and the root has been compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an array with the words that match' do
-          expect(container.scan 'hi').to eq %w(hi high highlight histerical)
-          expect(container.scan 'hig').to eq %w(high highlight)
-        end
-      end
-    end
-
-    context 'words that match are not contained' do
-      before do
-        add_word container, 'hello'
-      end
-
-      it 'returns an empty array' do
-        expect(container.scan 'hi').to eq %w()
-      end
-
-      context 'and the root has been compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an empty array' do
-          expect(container.scan 'hi').to eq %w()
-        end
-      end
-    end
-  end
-
-  describe '#words_within' do
-    before do
-      add_words container, %w(one word and other words)
-    end
-
-    context 'phrase does not contain any words' do
-      it 'returns an empty array' do
-        expect(container.words_within 'xyz').to match_array []
-      end
-
-      context 'and the node is compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an empty array' do
-          expect(container.words_within 'xyz').to match_array []
-        end
-      end
-    end
-
-    context 'phrase contains one word at the start of the phrase' do
-      it 'returns an array with the word found in the phrase' do
-        expect(container.words_within 'word').to match_array %w(word)
-        expect(container.words_within 'wordxyz').to match_array %w(word)
-      end
-
-      context 'and the node is compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an array with the word found in the phrase' do
-          expect(container.words_within 'word').to match_array %w(word)
-          expect(container.words_within 'wordxyz').to match_array %w(word)
-        end
-      end
-    end
-
-    context 'phrase contains one word at the end of the phrase' do
-      it 'returns an array with the word found in the phrase' do
-        expect(container.words_within 'xyz word').to match_array %w(word)
-      end
-
-      context 'and the node is compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an array with the word found in the phrase' do
-          expect(container.words_within 'xyz word').to match_array %w(word)
-        end
-      end
-    end
-
-    context 'phrase contains a few words' do
-      it 'returns an array with all words found in the phrase' do
-        expect(container.words_within 'xyzword otherzxyone')
-          .to match_array %w(word other one)
-      end
-
-      context 'and the node is compressed' do
-        before do
-          container.compress!
-        end
-
-        it 'returns an array with all words found in the phrase' do
-          expect(container.words_within 'xyzword otherzxyone')
-            .to match_array %w(word other one)
-        end
-      end
-    end
-  end
-
-  describe '#words_within?' do
-    before do
-      add_words container, %w(one word and other words)
-    end
-
-    context 'phrase does not contain any words' do
-      it 'returns false' do
-        expect(container.words_within? 'xyz').to be false
-      end
-    end
-
-    context 'phrase contains any word' do
-      it 'returns true' do
-        expect(container.words_within? 'xyz words').to be true
-        expect(container.words_within? 'xyzone word').to be true
-      end
-    end
-  end
-
-  describe '#==' do
-    context 'when the root nodes are the same' do
-      let(:other_container) do
-        Rambling::Trie::Container.new container.root, compressor
-      end
-
-      it 'returns true' do
-        expect(container).to eq other_container
-      end
-    end
-
-    context 'when the root nodes are not the same' do
-      let(:other_root) { Rambling::Trie::Nodes::Raw.new }
-      let(:other_container) do
-        Rambling::Trie::Container.new other_root, compressor
-      end
-
-      before do
-        add_word other_container, 'hola'
-      end
-
-      it 'returns false' do
-        expect(container).not_to eq other_container
-      end
-    end
-  end
-
-  describe '#each' do
-    before do
-      add_words container, %w(yes no why)
-    end
-
-    it 'returns an enumerator when no block is given' do
-      expect(container.each).to be_instance_of Enumerator
-    end
-
-    it 'iterates through all words contained' do
-      expect(container.each.to_a).to eq %w(yes no why)
-    end
-  end
-
-  describe '#inspect' do
-    before do
-      add_words container, %w(a few words hello hell)
-    end
-
-    it 'returns the container class name plus the root inspection' do
-      expect(container.inspect).to eq one_line <<~CONTAINER
-        #<Rambling::Trie::Container root: #<Rambling::Trie::Nodes::Raw letter: nil,
-        terminal: nil,
-        children: [:a, :f, :w, :h]>>
-      CONTAINER
     end
   end
 end

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -289,7 +289,6 @@ describe Rambling::Trie::Container do
     context 'when word is not contained' do
       before { add_word container, 'hello' }
 
-      # rubocop:disable RSpec/RepeatedExampleGroupBody
       context 'with uncompressed root' do
         it_behaves_like 'a non matching tree'
       end
@@ -299,7 +298,6 @@ describe Rambling::Trie::Container do
 
         it_behaves_like 'a non matching tree'
       end
-      # rubocop:enable RSpec/RepeatedExampleGroupBody
     end
   end
 

--- a/spec/lib/rambling/trie/enumerable_spec.rb
+++ b/spec/lib/rambling/trie/enumerable_spec.rb
@@ -8,21 +8,19 @@ module Rambling
       let(:node) { Rambling::Trie::Nodes::Raw.new }
       let(:words) { %w(add some words and another word) }
 
-      before do
-        add_words node, words
-      end
+      before { add_words node, words }
 
       describe '#each' do
         it 'returns an enumerator' do
           expect(node.each).to be_a Enumerator
         end
 
-        it 'includes every word contained in the trie' do
-          node.each do |word|
-            expect(words).to include word
-          end
-
+        it 'has the same word count as the trie' do
           expect(node.count).to eq words.count
+        end
+
+        it 'includes every word contained in the trie' do
+          node.each { |word| expect(words).to include word }
         end
       end
 
@@ -32,9 +30,15 @@ module Rambling
         end
       end
 
-      it 'includes the core Enumerable module' do
+      it 'includes #all? from the core Enumerable module' do
         expect(node.all? { |word| words.include? word }).to be true
+      end
+
+      it 'includes #any? from the core Enumerable module' do
         expect(node.any? { |word| word.start_with? 's' }).to be true
+      end
+
+      it 'includes #to_a from the core Enumerable module' do
         expect(node.to_a).to match_array words
       end
     end

--- a/spec/lib/rambling/trie/inspectable_spec.rb
+++ b/spec/lib/rambling/trie/inspectable_spec.rb
@@ -13,19 +13,23 @@ describe Rambling::Trie::Inspectable do
     let(:child) { node[:o] }
     let(:terminal_node) { node[:o][:n][:l][:y] }
 
-    it 'returns a pretty printed version of the node' do
+    it 'returns a pretty printed version of the parent node' do
       expect(node.inspect).to eq one_line <<~RAW
         #<Rambling::Trie::Nodes::Raw letter: nil,
         terminal: nil,
         children: [:o, :t, :w]>
       RAW
+    end
 
+    it 'returns a pretty printed version of the child node' do
       expect(child.inspect).to eq one_line <<~CHILD
         #<Rambling::Trie::Nodes::Raw letter: :o,
         terminal: nil,
         children: [:n]>
       CHILD
+    end
 
+    it 'returns a pretty printed version of the terminal node' do
       expect(terminal_node.inspect).to eq one_line <<~TERMINAL
         #<Rambling::Trie::Nodes::Raw letter: :y,
         terminal: true,
@@ -33,18 +37,20 @@ describe Rambling::Trie::Inspectable do
       TERMINAL
     end
 
-    context 'for a compressed node' do
+    context 'with a compressed node' do
       let(:compressor) { Rambling::Trie::Compressor.new }
       let(:compressed) { compressor.compress node }
       let(:compressed_child) { compressed[:o] }
 
-      it 'returns a pretty printed version of the compressed node' do
+      it 'returns a pretty printed version of the compressed parent node' do
         expect(compressed.inspect).to eq one_line <<~COMPRESSED
           #<Rambling::Trie::Nodes::Compressed letter: nil,
           terminal: nil,
           children: [:o, :t, :w]>
         COMPRESSED
+      end
 
+      it 'returns a pretty printed version of the compressed child node' do
         expect(compressed_child.inspect).to eq one_line <<~CHILD
           #<Rambling::Trie::Nodes::Compressed letter: :only,
           terminal: true,

--- a/spec/lib/rambling/trie/nodes/node_spec.rb
+++ b/spec/lib/rambling/trie/nodes/node_spec.rb
@@ -4,6 +4,6 @@ require 'spec_helper'
 
 describe Rambling::Trie::Nodes::Node do
   it_behaves_like 'a trie node' do
-    let(:node) { Rambling::Trie::Nodes::Node.new }
+    let(:node) { described_class.new }
   end
 end

--- a/spec/lib/rambling/trie/nodes/raw_spec.rb
+++ b/spec/lib/rambling/trie/nodes/raw_spec.rb
@@ -31,26 +31,28 @@ describe Rambling::Trie::Nodes::Raw do
 
   describe '#add' do
     context 'when the node has no branches' do
-      before do
-        add_word node, 'abc'
-      end
+      before { add_word node, 'abc' }
 
       it 'adds only one child' do
         expect(node.children.size).to eq 1
       end
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'adds the full subtree' do
         expect(node[:a]).not_to be_nil
         expect(node[:a][:b]).not_to be_nil
         expect(node[:a][:b][:c]).not_to be_nil
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'marks only the last child as terminal' do
         expect(node).not_to be_terminal
         expect(node[:a]).not_to be_terminal
         expect(node[:a][:b]).not_to be_terminal
         expect(node[:a][:b][:c]).to be_terminal
       end
+      # rubocop:enable RSpec/MultipleExpectations
     end
 
     context 'when a word is added more than once' do
@@ -59,19 +61,23 @@ describe Rambling::Trie::Nodes::Raw do
         add_word node, 'ack'
       end
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'only counts it once' do
         expect(node.children.size).to eq 1
         expect(node[:a].children.size).to eq 1
         expect(node[:a][:c].children.size).to eq 1
         expect(node[:a][:c][:k].children.size).to eq 0
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'does not change the terminal nodes in the tree' do
         expect(node).not_to be_terminal
         expect(node[:a]).not_to be_terminal
         expect(node[:a][:c]).not_to be_terminal
         expect(node[:a][:c][:k]).to be_terminal
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
       it 'still returns the "added" node' do
         child = add_word node, 'ack'
@@ -80,21 +86,20 @@ describe Rambling::Trie::Nodes::Raw do
     end
 
     context 'when the word does not exist in the tree but the letters do' do
-      before do
-        add_words node, %w(ack a)
-      end
+      before { add_words node, %w(ack a) }
 
       it 'does not add another branch' do
         expect(node.children.size).to eq 1
       end
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'marks the corresponding node as terminal' do
-        expect(node[:a]).to be_terminal
-
         expect(node).not_to be_terminal
+        expect(node[:a]).to be_terminal
         expect(node[:a][:c]).not_to be_terminal
         expect(node[:a][:c][:k]).to be_terminal
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
       it 'returns the added node' do
         child = add_word node, 'a'
@@ -106,10 +111,8 @@ describe Rambling::Trie::Nodes::Raw do
       let(:parent) { described_class.new }
       let(:node) { described_class.new :a, parent }
 
-      context 'adding an empty string' do
-        before do
-          add_word node, ''
-        end
+      context 'when adding an empty string' do
+        before { add_word node, '' }
 
         it 'does not alter the node letter' do
           expect(node.letter).to eq :a
@@ -124,19 +127,19 @@ describe Rambling::Trie::Nodes::Raw do
         end
       end
 
-      context 'adding a one letter word' do
-        before do
-          add_word node, 'b'
-        end
+      context 'when adding a one letter word' do
+        before { add_word node, 'b' }
 
         it 'does not alter the node letter' do
           expect(node.letter).to eq :a
         end
 
+        # rubocop:disable RSpec/MultipleExpectations
         it 'adds a child with the expected letter' do
           expect(node.children.size).to eq 1
           expect(node.children.first.letter).to eq :b
         end
+        # rubocop:enable RSpec/MultipleExpectations
 
         it 'reports it has the expected letter a key' do
           expect(node).to have_key(:b)
@@ -155,15 +158,14 @@ describe Rambling::Trie::Nodes::Raw do
         end
       end
 
-      context 'adding a large word' do
-        before do
-          add_word node, 'mplified'
-        end
+      context 'when adding a large word' do
+        before { add_word node, 'mplified' }
 
         it 'marks the last letter as terminal' do
           expect(node[:m][:p][:l][:i][:f][:i][:e][:d]).to be_terminal
         end
 
+        # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
         it 'does not mark any other letter as terminal' do
           expect(node[:m][:p][:l][:i][:f][:i][:e]).not_to be_terminal
           expect(node[:m][:p][:l][:i][:f][:i]).not_to be_terminal
@@ -173,6 +175,7 @@ describe Rambling::Trie::Nodes::Raw do
           expect(node[:m][:p]).not_to be_terminal
           expect(node[:m]).not_to be_terminal
         end
+        # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
       end
     end
   end

--- a/spec/lib/rambling/trie/nodes/raw_spec.rb
+++ b/spec/lib/rambling/trie/nodes/raw_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Nodes::Raw do
-  let(:node) { Rambling::Trie::Nodes::Raw.new }
+  let(:node) { described_class.new }
 
   it_behaves_like 'a trie node implementation' do
     def add_word_to_tree word
@@ -103,8 +103,8 @@ describe Rambling::Trie::Nodes::Raw do
     end
 
     context 'when the node has a letter and a parent' do
-      let(:parent) { Rambling::Trie::Nodes::Raw.new }
-      let(:node) { Rambling::Trie::Nodes::Raw.new :a, parent }
+      let(:parent) { described_class.new }
+      let(:node) { described_class.new :a, parent }
 
       context 'adding an empty string' do
         before do

--- a/spec/lib/rambling/trie/readers/plain_text_spec.rb
+++ b/spec/lib/rambling/trie/readers/plain_text_spec.rb
@@ -3,13 +3,15 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Readers::PlainText do
+  subject(:reader) { described_class.new }
+
   describe '#each_word' do
     let(:filepath) { File.join(::SPEC_ROOT, 'assets', 'test_words.en_US.txt') }
     let(:words) { File.readlines(filepath).map(&:chomp) }
 
     it 'yields every word yielded by the file' do
       yielded = []
-      subject.each_word(filepath) { |word| yielded << word }
+      reader.each_word(filepath) { |word| yielded << word }
       expect(yielded).to eq words
     end
   end

--- a/spec/lib/rambling/trie/serializers/file_spec.rb
+++ b/spec/lib/rambling/trie/serializers/file_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::File do
   it_behaves_like 'a serializer' do
-    let(:serializer) { Rambling::Trie::Serializers::File.new }
+    let(:serializer) { described_class.new }
     let(:format) { :file }
 
     let(:content) { trie.to_a.join ' ' }

--- a/spec/lib/rambling/trie/serializers/file_spec.rb
+++ b/spec/lib/rambling/trie/serializers/file_spec.rb
@@ -4,9 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::File do
   it_behaves_like 'a serializer' do
-    let(:serializer) { described_class.new }
     let(:format) { :file }
-
     let(:content) { trie.to_a.join ' ' }
     let(:formatted_content) { content }
   end

--- a/spec/lib/rambling/trie/serializers/marshal_spec.rb
+++ b/spec/lib/rambling/trie/serializers/marshal_spec.rb
@@ -4,9 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Marshal do
   it_behaves_like 'a serializer' do
-    let(:serializer) { described_class.new }
     let(:format) { :marshal }
-
     let(:formatted_content) { Marshal.dump content }
   end
 end

--- a/spec/lib/rambling/trie/serializers/marshal_spec.rb
+++ b/spec/lib/rambling/trie/serializers/marshal_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Marshal do
   it_behaves_like 'a serializer' do
-    let(:serializer) { Rambling::Trie::Serializers::Marshal.new }
+    let(:serializer) { described_class.new }
     let(:format) { :marshal }
 
     let(:formatted_content) { Marshal.dump content }

--- a/spec/lib/rambling/trie/serializers/yaml_spec.rb
+++ b/spec/lib/rambling/trie/serializers/yaml_spec.rb
@@ -4,9 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Yaml do
   it_behaves_like 'a serializer' do
-    let(:serializer) { described_class.new }
     let(:format) { :yml }
-
     let(:formatted_content) { YAML.dump content }
   end
 end

--- a/spec/lib/rambling/trie/serializers/yaml_spec.rb
+++ b/spec/lib/rambling/trie/serializers/yaml_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Yaml do
   it_behaves_like 'a serializer' do
-    let(:serializer) { Rambling::Trie::Serializers::Yaml.new }
+    let(:serializer) { described_class.new }
     let(:format) { :yml }
 
     let(:formatted_content) { YAML.dump content }

--- a/spec/lib/rambling/trie/serializers/zip_spec.rb
+++ b/spec/lib/rambling/trie/serializers/zip_spec.rb
@@ -6,7 +6,7 @@ describe Rambling::Trie::Serializers::Zip do
   it_behaves_like 'a serializer' do
     let(:properties) { Rambling::Trie::Configuration::Properties.new }
     let(:serializer) { described_class.new properties }
-    let(:format) { 'marshal.zip' }
+    let(:format) { :zip }
 
     before do
       properties.tmp_path = tmp_path

--- a/spec/lib/rambling/trie/serializers/zip_spec.rb
+++ b/spec/lib/rambling/trie/serializers/zip_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Rambling::Trie::Serializers::Zip do
   it_behaves_like 'a serializer' do
     let(:properties) { Rambling::Trie::Configuration::Properties.new }
-    let(:serializer) { Rambling::Trie::Serializers::Zip.new properties }
+    let(:serializer) { described_class.new properties }
     let(:format) { 'marshal.zip' }
 
     before do

--- a/spec/lib/rambling/trie/stringifyable_spec.rb
+++ b/spec/lib/rambling/trie/stringifyable_spec.rb
@@ -6,17 +6,15 @@ describe Rambling::Trie::Stringifyable do
   describe '#as_word' do
     let(:node) { Rambling::Trie::Nodes::Raw.new }
 
-    context 'for an empty node' do
-      before do
-        add_word node, ''
-      end
+    context 'with an empty node' do
+      before { add_word node, '' }
 
       it 'returns nil' do
         expect(node.as_word).to be_empty
       end
     end
 
-    context 'for one letter' do
+    context 'with one letter' do
       before do
         node.letter = :a
         add_word node, ''
@@ -27,7 +25,7 @@ describe Rambling::Trie::Stringifyable do
       end
     end
 
-    context 'for a small word' do
+    context 'with a small word' do
       before do
         node.letter = :a
         add_word node, 'll'
@@ -43,7 +41,7 @@ describe Rambling::Trie::Stringifyable do
       end
     end
 
-    context 'for a long word' do
+    context 'with a long word' do
       before do
         node.letter = :b
         add_word node, 'eautiful'
@@ -54,7 +52,7 @@ describe Rambling::Trie::Stringifyable do
       end
     end
 
-    context 'for a node with nil letter' do
+    context 'with a node with nil letter' do
       let(:node) { Rambling::Trie::Nodes::Raw.new nil }
 
       it 'returns nil' do
@@ -62,7 +60,7 @@ describe Rambling::Trie::Stringifyable do
       end
     end
 
-    context 'for a compressed node' do
+    context 'with a compressed node' do
       let(:compressor) { Rambling::Trie::Compressor.new }
       let(:compressed_node) { compressor.compress node }
 
@@ -71,12 +69,18 @@ describe Rambling::Trie::Stringifyable do
         add_words node, %w(m dd)
       end
 
-      it 'returns the words for the terminal nodes' do
-        expect(compressed_node[:m].as_word).to eq 'am'
-        expect(compressed_node[:d].as_word).to eq 'add'
+      [
+        [:m, 'am'],
+        [:d, 'add'],
+      ].each do |test_params|
+        key, expected = test_params
+
+        it "returns the words for terminal nodes (#{key} => #{expected})" do
+          expect(compressed_node[key].as_word).to eq expected
+        end
       end
 
-      it 'raise an error for non terminal nodes' do
+      it 'raises an error for non terminal nodes' do
         expect { compressed_node.as_word }
           .to raise_error Rambling::Trie::InvalidOperation
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,8 @@ require 'support/config'
 
 %w(
   a_compressible_trie a_serializable_trie a_serializer a_trie_data_structure
-  a_trie_node a_trie_node_implementation
+  a_trie_node a_trie_node_implementation a_container_scan a_container_word
+  a_container_partial_word a_container_words_within
 ).each do |name|
   require File.join('support', 'shared_examples', name)
 end

--- a/spec/support/shared_examples/a_compressible_trie.rb
+++ b/spec/support/shared_examples/a_compressible_trie.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples_for 'a compressible trie' do
-  context 'and the trie is not compressed' do
+  context 'with an uncompressed trie' do
     it_behaves_like 'a trie data structure'
 
     it 'does not alter the input' do
@@ -16,7 +16,7 @@ shared_examples_for 'a compressible trie' do
     end
   end
 
-  context 'and the trie is compressed' do
+  context 'with an compressed trie' do
     let!(:original_root) { trie.root }
     let!(:original_keys) { original_root.children_tree.keys }
     let!(:original_values) { original_root.children_tree.values }
@@ -31,9 +31,15 @@ shared_examples_for 'a compressible trie' do
       expect(trie).to be_compressed
     end
 
-    it 'leaves the original root intact' do
+    it 'leaves the original root keys intact' do
       expect(original_root.children_tree.keys).to eq original_keys
+    end
+
+    it 'leaves the original trie keys intact' do
       expect(trie.children_tree.keys).to eq original_keys
+    end
+
+    it 'leaves the original trie values intact' do
       expect(trie.children_tree.values).not_to eq original_values
     end
   end

--- a/spec/support/shared_examples/a_container_partial_word.rb
+++ b/spec/support/shared_examples/a_container_partial_word.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a matching container#partial_word' do
+  %w(h he hell hello hi hig high).each do |prefix|
+    it 'matches part of the word' do
+      expect(container.partial_word? prefix).to be true
+    end
+  end
+end
+
+shared_examples_for 'a non-matching container#partial_word' do
+  it 'does not match any part of the word' do
+    %w(ha hal al).each do |word|
+      expect(container.partial_word? word).to be false
+    end
+  end
+end
+

--- a/spec/support/shared_examples/a_container_scan.rb
+++ b/spec/support/shared_examples/a_container_scan.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a matching container#scan' do
+  [
+    ['hi', %w(hi high highlight histerical)],
+    ['hig', %w(high highlight)],
+  ].each do |test_params|
+    prefix, expected = test_params
+
+    it "returns an array with the words that match '#{prefix}'" do
+      expect(container.scan prefix).to eq expected
+    end
+  end
+end

--- a/spec/support/shared_examples/a_container_word.rb
+++ b/spec/support/shared_examples/a_container_word.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a matching container#word' do
+  %w(hello high).each do |word|
+    it 'matches the whole word' do
+      expect(container.word? word).to be true
+    end
+  end
+end
+
+shared_examples_for 'a non-matching container#word' do
+  %w(halt al).each do |word|
+    it 'does not match the whole word' do
+      expect(container.word? word).to be false
+    end
+  end
+end
+
+shared_examples_for 'a propagating node' do
+  [
+    [true, 'Rambling::Trie::Nodes::Compressed'],
+    [false, 'Rambling::Trie::Nodes::Raw'],
+  ].each do |test_params|
+    compressed_value, instance_double_class = test_params
+
+    context "when root has compressed=#{compressed_value}" do
+      let(:root) do
+        instance_double(
+          instance_double_class,
+          :root,
+          compressed?: compressed_value,
+          word?: nil,
+          partial_word?: nil,
+        )
+      end
+
+      it 'calls the root with the word characters' do
+        container.public_send method, 'words'
+        expect(root).to have_received(method).with %w(w o r d s)
+      end
+    end
+  end
+
+end

--- a/spec/support/shared_examples/a_container_words_within.rb
+++ b/spec/support/shared_examples/a_container_words_within.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a matching container#words_within' do
+  [
+    ['word', %w(word)],
+    ['wordxyz', %w(word)],
+  ].each do |test_params|
+    phrase, expected = test_params
+
+    it "returns an array with the word found in the phrase '#{phrase}'" do
+      expect(container.words_within phrase).to match_array expected
+    end
+  end
+end
+
+shared_examples_for 'a non-matching container#words_within' do
+  it 'returns an array with all words found in the phrase' do
+    expect(container.words_within 'xyzword otherzxyone')
+      .to match_array %w(word other one)
+  end
+end
+
+shared_examples_for 'a matching container#words_within?' do
+    context 'when phrase does not contain any words' do
+      it 'returns false' do
+        expect(container.words_within? 'xyz').to be false
+      end
+    end
+
+    context 'when phrase contains any word' do
+      ['xyz words', 'xyzone word'].each do |phrase|
+        it "returns true for '#{phrase}'" do
+          expect(container.words_within? phrase).to be true
+        end
+      end
+    end
+end
+
+shared_examples_for 'a non-matching container#words_within?' do
+  it 'returns an array with all words found in the phrase' do
+    expect(container.words_within 'xyzword otherzxyone')
+      .to match_array %w(word other one)
+  end
+end

--- a/spec/support/shared_examples/a_serializable_trie.rb
+++ b/spec/support/shared_examples/a_serializable_trie.rb
@@ -4,22 +4,18 @@ shared_examples_for 'a serializable trie' do
   let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
   let(:filepath) { File.join tmp_path, "trie-root.#{format}" }
 
-  context 'and the trie is not compressed' do
-    before do
-      Rambling::Trie.dump trie_to_serialize, filepath
-    end
+  context 'with an uncompressed trie' do
+    before { Rambling::Trie.dump trie_to_serialize, filepath }
 
     it_behaves_like 'a compressible trie' do
       let(:trie) { Rambling::Trie.load filepath }
     end
   end
 
-  context 'and the trie is compressed' do
+  context 'with an compressed trie' do
     let(:trie) { Rambling::Trie.load filepath }
 
-    before do
-      Rambling::Trie.dump trie_to_serialize.compress!, filepath
-    end
+    before { Rambling::Trie.dump trie_to_serialize.compress!, filepath }
 
     it_behaves_like 'a trie data structure'
 

--- a/spec/support/shared_examples/a_serializer.rb
+++ b/spec/support/shared_examples/a_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples_for 'a serializer' do
+  subject(:serializer) { described_class.new }
+
   let(:trie) { Rambling::Trie.create }
   let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
   let(:filepath) { File.join tmp_path, "trie-root.#{format}" }

--- a/spec/support/shared_examples/a_trie_data_structure.rb
+++ b/spec/support/shared_examples/a_trie_data_structure.rb
@@ -2,25 +2,39 @@
 
 shared_examples_for 'a trie data structure' do
   it 'contains all the words previously provided' do
-    words.each do |word|
-      expect(trie).to include word
-      expect(trie.word? word).to be true
-    end
+    words.each { |word| expect(trie).to include word }
   end
 
-  it 'matches the start of all the words from the file' do
+  it 'returns true for #word? for all words previously provided' do
+    words.each { |word| expect(trie.word? word).to be true }
+  end
+
+  it 'matches the full word for all words in file' do
+    words.each { |word| expect(trie.match? word).to be true }
+  end
+
+  it 'matches the start of all the words in file' do
+    words.each { |word| expect(trie.match? word[0..-2]).to be true }
+  end
+
+  it 'returns true for #partial_word? with full word for all words in file' do
+    words.each { |word| expect(trie.partial_word? word).to be true }
+  end
+
+  it 'returns true for #partial_word? with the start of all words in file' do
+    words.each { |word| expect(trie.partial_word? word[0..-2]).to be true }
+  end
+
+  it 'extracts words within larger strings' do
     words.each do |word|
-      expect(trie.match? word).to be true
-      expect(trie.match? word[0..-2]).to be true
-      expect(trie.partial_word? word).to be true
-      expect(trie.partial_word? word[0..-2]).to be true
+      phrase = "x#{word}y"
+      expect(trie.words_within phrase).to include word
     end
   end
 
   it 'identifies words within larger strings' do
     words.each do |word|
       phrase = "x#{word}y"
-      expect(trie.words_within phrase).to include word
       expect(trie.words_within? phrase).to be true
     end
   end

--- a/spec/support/shared_examples/a_trie_node.rb
+++ b/spec/support/shared_examples/a_trie_node.rb
@@ -40,9 +40,7 @@ shared_examples_for 'a trie node' do
 
   describe '#root?' do
     context 'when the node has a parent' do
-      before do
-        node.parent = node
-      end
+      before { node.parent = node }
 
       it 'returns false' do
         expect(node).not_to be_root
@@ -50,9 +48,7 @@ shared_examples_for 'a trie node' do
     end
 
     context 'when the node does not have a parent' do
-      before do
-        node.parent = nil
-      end
+      before { node.parent = nil }
 
       it 'returns true' do
         expect(node).to be_root
@@ -61,12 +57,13 @@ shared_examples_for 'a trie node' do
   end
 
   describe '#terminal!' do
+    # rubocop:disable RSpec/MultipleExpectations
     it 'forces the node to be terminal' do
       expect(node).not_to be_terminal
       node.terminal!
-
       expect(node).to be_terminal
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it 'returns the node' do
       expect(node.terminal!).to eq node
@@ -75,7 +72,8 @@ shared_examples_for 'a trie node' do
 
   describe 'delegates and aliases' do
     let(:children_tree) do
-      double(
+      instance_double(
+        'Hash',
         :children_tree,
         :[] => 'value',
         :[]= => nil,
@@ -84,20 +82,21 @@ shared_examples_for 'a trie node' do
       )
     end
 
-    before do
-      node.children_tree = children_tree
-    end
+    before { node.children_tree = children_tree }
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'delegates `#[]` to its children tree' do
       expect(node[:key]).to eq 'value'
       expect(children_tree).to have_received(:[]).with :key
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it 'delegates `#[]=` to its children tree' do
       node[:key] = 'value'
       expect(children_tree).to have_received(:[]=).with(:key, 'value')
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'delegates `#key?` to its children tree' do
       allow(children_tree).to receive(:key?)
         .with(:present_key)
@@ -106,18 +105,26 @@ shared_examples_for 'a trie node' do
       expect(node).to have_key(:present_key)
       expect(node).not_to have_key(:absent_key)
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'delegates `#delete` to its children tree' do
       expect(node.delete :key).to be true
       expect(children_tree).to have_received(:delete).with :key
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
+    # rubocop:disable RSpec/ExampleLength
     it 'delegates `#children` to its children tree values' do
-      children = [double(:child_1), double(:child_2)]
+      children = [
+        instance_double('Rambling::Trie::Nodes::Node', :child_one),
+        instance_double('Rambling::Trie::Nodes::Node', :child_two),
+      ]
       allow(children_tree).to receive(:values).and_return children
 
       expect(node.children).to eq children
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'aliases `#has_key?` to `#key?`' do
       node.has_key? :nope

--- a/spec/support/shared_examples/a_trie_node_implementation.rb
+++ b/spec/support/shared_examples/a_trie_node_implementation.rb
@@ -12,26 +12,22 @@ shared_examples_for 'a trie node implementation' do
 
     context 'when the chars array is not empty' do
       context 'when the node has a tree that matches the characters' do
-        before do
-          add_word_to_tree 'abc'
-        end
+        before { add_word_to_tree 'abc' }
 
-        it 'returns true' do
-          expect(node.partial_word? %w(a)).to be true
-          expect(node.partial_word? %w(a b)).to be true
-          expect(node.partial_word? %w(a b c)).to be true
+        [%w(a), %w(a b), %w(a b c)].each do |letters|
+          it "returns true for '#{letters}'" do
+            expect(node.partial_word? letters).to be true
+          end
         end
       end
 
       context 'when the node has a tree that does not match the characters' do
-        before do
-          add_word_to_tree 'cba'
-        end
+        before { add_word_to_tree 'cba' }
 
-        it 'returns false' do
-          expect(node.partial_word? %w(a)).to be false
-          expect(node.partial_word? %w(a b)).to be false
-          expect(node.partial_word? %w(a b c)).to be false
+        [%w(a), %w(a b), %w(a b c)].each do |letters|
+          it "returns false for '#{letters}'" do
+            expect(node.partial_word? letters).to be false
+          end
         end
       end
     end
@@ -40,9 +36,7 @@ shared_examples_for 'a trie node implementation' do
   describe '#word?' do
     context 'when the chars array is empty' do
       context 'when the node is terminal' do
-        before do
-          node.terminal!
-        end
+        before { node.terminal! }
 
         it 'returns true' do
           expect(node.word? []).to be true
@@ -58,9 +52,7 @@ shared_examples_for 'a trie node implementation' do
 
     context 'when the chars array is not empty' do
       context 'when the node has a tree that matches all the characters' do
-        before do
-          add_word_to_tree 'abc'
-        end
+        before { add_word_to_tree 'abc' }
 
         it 'returns true' do
           expect(node.word? %w(a b c).map(&:dup)).to be true
@@ -68,13 +60,12 @@ shared_examples_for 'a trie node implementation' do
       end
 
       context 'when the node subtree does not match all the characters' do
-        before do
-          add_word_to_tree 'abc'
-        end
+        before { add_word_to_tree 'abc' }
 
-        it 'returns false' do
-          expect(node.word? %w(a).map(&:dup)).to be false
-          expect(node.word? %w(a b).map(&:dup)).to be false
+        [%w(a), %w(a b)].each do |letters|
+          it "returns false for '#{letters}'" do
+            expect(node.word? letters.map(&:dup)).to be false
+          end
         end
       end
     end
@@ -88,26 +79,34 @@ shared_examples_for 'a trie node implementation' do
     end
 
     context 'when the chars array is not empty' do
-      before do
-        add_words_to_tree %w(cba ccab)
-      end
+      before { add_words_to_tree %w(cba ccab) }
 
       context 'when the chars are found' do
-        it 'returns the found child' do
-          expect(node.scan %w(c)).to match_array %w(cba ccab)
-          expect(node.scan %w(c b)).to match_array %w(cba)
-          expect(node.scan %w(c b a)).to match_array %w(cba)
+        [
+          [%w(c), %w(cba ccab)],
+          [%w(c b), %w(cba)],
+          [%w(c b a), %w(cba)],
+        ].each do |test_params|
+          letters, expected = test_params
+
+          it "returns the corresponding children (#{letters} => #{expected})" do
+            expect(node.scan letters).to match_array expected
+          end
         end
       end
 
       context 'when the chars are not found' do
-        it 'returns a Nodes::Missing' do
-          expect(node.scan %w(a)).to be_a Rambling::Trie::Nodes::Missing
-          expect(node.scan %w(a b)).to be_a Rambling::Trie::Nodes::Missing
-          expect(node.scan %w(a b c)).to be_a Rambling::Trie::Nodes::Missing
-          expect(node.scan %w(c a)).to be_a Rambling::Trie::Nodes::Missing
-          expect(node.scan %w(c c b)).to be_a Rambling::Trie::Nodes::Missing
-          expect(node.scan %w(c b a d)).to be_a Rambling::Trie::Nodes::Missing
+        [
+          %w(a),
+          %w(a b),
+          %w(a b c),
+          %w(c a),
+          %w(c c b),
+          %w(c b a d),
+        ].each do |letters|
+          it "returns a Nodes::Missing for '#{letters}'" do
+            expect(node.scan letters).to be_a Rambling::Trie::Nodes::Missing
+          end
         end
       end
     end
@@ -120,9 +119,7 @@ shared_examples_for 'a trie node implementation' do
     end
 
     context 'when the node is terminal' do
-      before do
-        node.terminal!
-      end
+      before { node.terminal! }
 
       it 'adds itself to the words' do
         expect(node.match_prefix %w(g n i t e)).to include 'i'

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -144,7 +144,7 @@ class TestDelegate
   require 'forwardable'
   extend ::Forwardable
 
-  delegate [:[]] => :hash
+  delegate %i([]) => :hash
 
   attr_reader :hash
 
@@ -168,7 +168,7 @@ class TestMyForwardable
 
   extend TestMyForwardable::Forwardable
 
-  delegate [:[]] => :hash
+  delegate %i([]) => :hash
 
   attr_reader :hash
 

--- a/tasks/performance.rb
+++ b/tasks/performance.rb
@@ -14,7 +14,7 @@ task :performance, arg_names => dependencies do |_, args|
 
   configuration = Performance::Configuration.new
   task = Performance::Task.new configuration
-  task.run **args
+  task.run(**args)
 end
 
 namespace :performance do

--- a/tasks/performance/configuration.rb
+++ b/tasks/performance/configuration.rb
@@ -13,9 +13,9 @@ module Performance
       type ||= 'all'
       method ||= 'all'
 
-      if type == 'all'
+      if 'all' == type
         get_all_types method
-      elsif method == 'all'
+      elsif 'all' == method
         get_all_methods type
       else
         tasks[type][method]
@@ -165,7 +165,7 @@ module Performance
 
     def lookups_scan_raw
       lambda do |iterations|
-        if iterations.nil? || iterations == 200_000
+        if iterations.nil? || 200_000 == iterations
           Performance::SubTasks::Lookups::Scan::Raw.new
         else
           Performance::SubTasks::Lookups::Scan::Raw.new(
@@ -181,7 +181,7 @@ module Performance
 
     def lookups_scan_compressed _ = nil
       lambda do |iterations|
-        if iterations.nil? || iterations == 200_000
+        if iterations.nil? || 200_000 == iterations
           Performance::SubTasks::Lookups::Scan::Compressed.new
         else
           Performance::SubTasks::Lookups::Scan::Compressed.new(

--- a/tasks/performance/reporters/benchmark.rb
+++ b/tasks/performance/reporters/benchmark.rb
@@ -7,6 +7,7 @@ module Performance
   module Reporters
     class Benchmark < Performance::Reporters::Reporter
       def initialize _ = nil, output = $stdout.dup
+        super()
         @output = output
       end
 

--- a/tasks/performance/reporters/call_tree_profile.rb
+++ b/tasks/performance/reporters/call_tree_profile.rb
@@ -6,6 +6,7 @@ module Performance
   module Reporters
     class CallTreeProfile < Performance::Reporters::Reporter
       def initialize dirname
+        super()
         @dirname = dirname
       end
 

--- a/tasks/performance/reporters/flamegraph.rb
+++ b/tasks/performance/reporters/flamegraph.rb
@@ -6,6 +6,7 @@ module Performance
   module Reporters
     class Flamegraph < Performance::Reporters::Reporter
       def initialize filename
+        super()
         @filename = filename
       end
 

--- a/tasks/performance/reporters/memory_profile.rb
+++ b/tasks/performance/reporters/memory_profile.rb
@@ -6,6 +6,7 @@ module Performance
   module Reporters
     class MemoryProfile < Performance::Reporters::Reporter
       def initialize filename
+        super()
         @filename = filename
       end
 

--- a/tasks/performance/reporters/reporter.rb
+++ b/tasks/performance/reporters/reporter.rb
@@ -12,13 +12,11 @@ module Performance
       include Helpers::Path
       include Helpers::Time
 
-      def report iterations = 1, params = nil
+      def report iterations = 1, params = nil, &block
         params = Array params
         params << nil unless params.any?
 
-        do_report iterations, params do |param|
-          yield param
-        end
+        do_report iterations, params, &block
       end
     end
   end

--- a/tasks/performance/sub_tasks/initialization.rb
+++ b/tasks/performance/sub_tasks/initialization.rb
@@ -8,6 +8,7 @@ module Performance
       include Helpers::Path
 
       def initialize iterations = 5
+        super()
         @iterations = iterations
       end
 

--- a/tasks/performance/sub_tasks/lookups/lookup.rb
+++ b/tasks/performance/sub_tasks/lookups/lookup.rb
@@ -9,6 +9,7 @@ module Performance
         include Helpers::Trie
 
         def initialize iterations = 200_000
+          super()
           @iterations = iterations
         end
 

--- a/tasks/performance/sub_tasks/lookups/scan/compressed.rb
+++ b/tasks/performance/sub_tasks/lookups/scan/compressed.rb
@@ -10,6 +10,7 @@ module Performance
           include Helpers::Trie
 
           def initialize params_to_iterations = default_params
+            super()
             @params_to_iterations = params_to_iterations
           end
 

--- a/tasks/performance/sub_tasks/lookups/scan/raw.rb
+++ b/tasks/performance/sub_tasks/lookups/scan/raw.rb
@@ -10,6 +10,7 @@ module Performance
           include Helpers::Trie
 
           def initialize params_to_iterations = default_params
+            super()
             @params_to_iterations = params_to_iterations
           end
 


### PR DESCRIPTION
#### Issues found in `lib/` and `tasks/`

1. Explicitly disable `Style/ExplicitBlockArgument` due to performance hits ([0a6aec0](https://github.com/gonzedge/rambling-trie/pull/24/commits/0a6aec07b6c5c00ecf527f8233ec668651ee1d93))
2. Add missing `super`s
3. Yoda-style conditionals
4. Bump target ruby required version to current min supported (`2.7.0`)

#### Issues found in `spec/`

1. Use `instance_double` instead of `double`
2. Split tests into single-assertion specs when parameterization is possible; disable otherwise
3. Use `let!` instead of instance variables
4. Remove duplicate test groups
5. Use `when` at the start of `context` block descriptions
6. Use `described_class`, `subject` in specs where possible
7. Single-line `before` where possible

#### Other

1. Explicitly add `rubocop-performance`, `rubocop-rake`, `rubocop-rspec` plugins
2. Remove unused `Rails` rules
3. Remove unused/deprecated `RSpec`/`Layout`/`Style`/`Lint` rules