### PR TITLE
Add missing `compress!` in container spec

### DIFF
--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -392,6 +392,8 @@ describe Rambling::Trie::Container do
       end
 
       context 'and the root has been compressed' do
+        before { container.compress! }
+
         it_behaves_like 'a non matching tree'
       end
     end


### PR DESCRIPTION
To actually test the non-matching tree shared example for compressed tries.