### PR TITLE
Update badges, CI and coveralls reporting

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis-ci
+service_name: semaphore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,6 +23,7 @@ blocks:
       epilogue:
         always:
           commands:
+            - echo $SEMAPHORE_THREAD_RESULT
             - exitcode=$(if [ "$SEMAPHORE_THREAD_RESULT" == "passed" ]; then echo 0; else echo 1; fi)
             - ./cc-test-reporter after-build --exit-code $exitcode
             - test-results publish junit.xml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,12 +19,12 @@ blocks:
       jobs:
         - name: bundle exec rspec
           commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+            - bundle exec rspec --format RspecJunitFormatter --out report.xml
       epilogue:
         always:
           commands:
             - ./cc-test-reporter after-build
-            - test-results publish junit.xml
+            - test-results publish report.xml
 #   - name: 3.2.0
 #     dependencies: []
 #     task:
@@ -253,9 +253,14 @@ blocks:
 #         - name: bundle exec rspec
 #           commands:
 #             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-# after_pipeline:
-#   task:
-#     jobs:
-#       - name: test report
-#         commands:
-#           - test-results gen-pipeline-report
+global_job_config:
+  epilogue:
+    always:
+      commands:
+        - '[[ -f report.xml ]] && test-results publish report.xml'
+after_pipeline:
+  task:
+    jobs:
+      - name: test report
+        commands:
+          - test-results gen-pipeline-report

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,13 +4,16 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu2004
+global_job_config:
+  prologue:
+    commands:
+      - checkout
 blocks:
   - name: 3.2.2
     dependencies: []
     task:
       prologue:
         commands:
-          - checkout
           - sem-version ruby 3.2.2
           - bundle install
       jobs:
@@ -21,234 +24,259 @@ blocks:
         always:
           commands:
             - '[[ -f report.xml ]] && test-results publish report.xml'
-#   - name: 3.2.0
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.2.0
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.1.3
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.1.3
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.1.2
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.1.2
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.1.1
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.1.1
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.1.0
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.1.0
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.5
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.5
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.4
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.4
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.3
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.3
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.2
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.2
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.1
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.1
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 3.0.0
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 3.0.0
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.7
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.7
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.6
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.6
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.5
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.5
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.4
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.4
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.3
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.3
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.2
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.2
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.1
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.1
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-#   - name: 2.7.0
-#     dependencies: []
-#     task:
-#       prologue:
-#         commands:
-#           - checkout
-#           - sem-version ruby 2.7.0
-#           - bundle install
-#       jobs:
-#         - name: bundle exec rspec
-#           commands:
-#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+  # - name: 3.2.1
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.2.1
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.2.0
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.2.0
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.1.4
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.1.4
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.1.3
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.1.3
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.1.2
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.1.2
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.1.1
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.1.1
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.1.0
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.1.0
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.6
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.6
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.5
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.5
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.4
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.4
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.3
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.3
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.2
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.2
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.1
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.1
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 3.0.0
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 3.0.0
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.8
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.8
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.7
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.7
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.6
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.6
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.5
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.5
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.4
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.4
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.3
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.3
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.2
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.2
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.1
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.1
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
+  # - name: 2.7.0
+  #   dependencies: []
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - sem-version ruby 2.7.0
+  #         - bundle install
+  #     jobs:
+  #       - name: bundle exec rspec
+  #         commands:
+  #           - bundle exec rspec
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,10 +12,7 @@ blocks:
         commands:
           - checkout
           - sem-version ruby 3.2.2
-          - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          - chmod +x ./cc-test-reporter
           - bundle install
-          - ./cc-test-reporter before-build
       jobs:
         - name: bundle exec rspec
           commands:
@@ -23,8 +20,7 @@ blocks:
       epilogue:
         always:
           commands:
-            - ./cc-test-reporter after-build
-            - test-results publish report.xml
+            - '[[ -f report.xml ]] && test-results publish report.xml'
 #   - name: 3.2.0
 #     dependencies: []
 #     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -249,11 +249,6 @@ blocks:
 #         - name: bundle exec rspec
 #           commands:
 #             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-global_job_config:
-  epilogue:
-    always:
-      commands:
-        - '[[ -f report.xml ]] && test-results publish report.xml'
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,9 +23,7 @@ blocks:
       epilogue:
         always:
           commands:
-            - echo $SEMAPHORE_THREAD_RESULT
-            - exitcode=$(if [ "$SEMAPHORE_THREAD_RESULT" == "passed" ]; then echo 0; else echo 1; fi)
-            - ./cc-test-reporter after-build --exit-code $exitcode
+            - ./cc-test-reporter after-build
             - test-results publish junit.xml
 #   - name: 3.2.0
 #     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,248 +35,248 @@ blocks:
         - name: bundle exec rspec
           commands:
             - bundle exec rspec
-  # - name: 3.2.0
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.2.0
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.1.4
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.1.4
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.1.3
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.1.3
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.1.2
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.1.2
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.1.1
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.1.1
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.1.0
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.1.0
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.6
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.6
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.5
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.5
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.4
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.4
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.3
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.3
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.2
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.2
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.1
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.1
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 3.0.0
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.0.0
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.8
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.8
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.7
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.7
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.6
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.6
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.5
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.5
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.4
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.4
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.3
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.3
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.2
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.2
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.1
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.1
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
-  # - name: 2.7.0
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 2.7.0
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
+  - name: 3.2.0
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.2.0
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.1.4
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.1.4
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.1.3
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.1.3
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.1.2
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.1.2
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.1.1
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.1.1
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.1.0
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.1.0
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.6
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.6
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.5
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.5
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.4
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.4
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.3
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.3
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.2
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.2
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.1
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.1
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 3.0.0
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.0.0
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.8
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.8
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.7
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.7
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.6
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.6
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.5
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.5
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.4
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.4
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.3
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.3
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.2
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.2
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.1
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.1
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
+  - name: 2.7.0
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 2.7.0
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: ruby
+name: Run specs in all supported rubies
 agent:
   machine:
     type: e1-standard-2
@@ -24,17 +24,17 @@ blocks:
         always:
           commands:
             - '[[ -f report.xml ]] && test-results publish report.xml'
-  # - name: 3.2.1
-  #   dependencies: []
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - sem-version ruby 3.2.1
-  #         - bundle install
-  #     jobs:
-  #       - name: bundle exec rspec
-  #         commands:
-  #           - bundle exec rspec
+  - name: 3.2.1
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - sem-version ruby 3.2.1
+          - bundle install
+      jobs:
+        - name: bundle exec rspec
+          commands:
+            - bundle exec rspec
   # - name: 3.2.0
   #   dependencies: []
   #   task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,14 +5,17 @@ agent:
     type: e1-standard-2
     os_image: ubuntu2004
 blocks:
-  - name: 3.2.1
+  - name: 3.2.2
     dependencies: []
     task:
       prologue:
         commands:
           - checkout
-          - sem-version ruby 3.2.1
+          - sem-version ruby 3.2.2
+          - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          - chmod +x ./cc-test-reporter
           - bundle install
+          - ./cc-test-reporter before-build
       jobs:
         - name: bundle exec rspec
           commands:
@@ -20,238 +23,240 @@ blocks:
       epilogue:
         always:
           commands:
+            - exitcode=$(if [ "$SEMAPHORE_THREAD_RESULT" == "passed" ]; then echo 0; else echo 1; fi)
+            - ./cc-test-reporter after-build --exit-code $exitcode
             - test-results publish junit.xml
-  - name: 3.2.0
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.2.0
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.1.3
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.1.3
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.1.2
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.1.2
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.1.1
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.1.1
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.1.0
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.1.0
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.5
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.5
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.4
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.4
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.3
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.3
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.2
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.2
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.1
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.1
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 3.0.0
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 3.0.0
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.7
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.7
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.6
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.6
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.5
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.5
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.4
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.4
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.3
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.3
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.2
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.2
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.1
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.1
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-  - name: 2.7.0
-    dependencies: []
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby 2.7.0
-          - bundle install
-      jobs:
-        - name: bundle exec rspec
-          commands:
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
-after_pipeline:
-  task:
-    jobs:
-      - name: test report
-        commands:
-          - test-results gen-pipeline-report
+#   - name: 3.2.0
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.2.0
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.1.3
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.1.3
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.1.2
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.1.2
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.1.1
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.1.1
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.1.0
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.1.0
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.5
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.5
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.4
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.4
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.3
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.3
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.2
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.2
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.1
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.1
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 3.0.0
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 3.0.0
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.7
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.7
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.6
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.6
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.5
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.5
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.4
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.4
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.3
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.3
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.2
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.2
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.1
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.1
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+#   - name: 2.7.0
+#     dependencies: []
+#     task:
+#       prologue:
+#         commands:
+#           - checkout
+#           - sem-version ruby 2.7.0
+#           - bundle install
+#       jobs:
+#         - name: bundle exec rspec
+#           commands:
+#             - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format documentation
+# after_pipeline:
+#   task:
+#     jobs:
+#       - name: test report
+#         commands:
+#           - test-results gen-pipeline-report

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 [gemnasium_link]: https://gemnasium.com/gonzedge/rambling-trie
 [github_user_gonzedge]: https://github.com/gonzedge
 [inch_ci_badge]: https://inch-ci.org/github/gonzedge/rambling-trie.svg?branch=master
-[inch_ci_link]: https://inch-ci.org/github/gonzedge/rambling-trie
+[inch_ci_link]: http://rubydoc.info/gems/rambling-trie
 [license_badge]: https://badges.frapsoft.com/os/mit/mit.svg?v=103
 [license_link]: https://opensource.org/licenses/mit-license.php
 [marshal]: https://ruby-doc.org/core-2.7.0/Marshal.html

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Gem Version][badge_fury_badge]][badge_fury_link]
 [![Downloads][downloads_badge]][downloads_link]
 [![Build Status][semaphore_ci_badge]][semaphore_ci_link]
-[![Code Climate][code_climate_badge]][code_climage_link]
 [![Coverage Status][coveralls_badge]][coveralls_link]
+[![Code Climate][code_climate_badge]][code_climate_link]
+[![Issue Count][code_climate_issues_badge]][code_climate_link]
 [![Documentation Status][inch_ci_badge]][inch_ci_link]
 [![License][license_badge]][license_link]
 
@@ -284,8 +285,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 [badge_fury_badge]: https://badge.fury.io/rb/rambling-trie.svg?version=2.3.0
 [badge_fury_link]: https://badge.fury.io/rb/rambling-trie
 [chruby]: https://github.com/postmodern/chruby
-[code_climage_link]: https://codeclimate.com/github/gonzedge/rambling-trie
 [code_climate_badge]: https://codeclimate.com/github/gonzedge/rambling-trie/badges/gpa.svg
+[code_climate_issues_badge]: https://codeclimate.com/github/gonzedge/rambling-trie/badges/issue_count.svg
+[code_climate_link]: https://codeclimate.com/github/gonzedge/rambling-trie
 [coveralls_badge]: https://img.shields.io/coveralls/gonzedge/rambling-trie.svg
 [coveralls_link]: https://coveralls.io/r/gonzedge/rambling-trie
 [downloads_badge]: https://img.shields.io/gem/dt/rambling-trie.svg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rambling Trie
 
 [![Gem Version][badge_fury_badge]][badge_fury_link]
+[![Downloads][downloads_badge]][downloads_link]
 [![Build Status][semaphore_ci_badge]][semaphore_ci_link]
 [![Code Climate][code_climate_badge]][code_climage_link]
 [![Coverage Status][coveralls_badge]][coveralls_link]
@@ -287,6 +288,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 [code_climate_badge]: https://codeclimate.com/github/gonzedge/rambling-trie/badges/gpa.svg
 [coveralls_badge]: https://img.shields.io/coveralls/gonzedge/rambling-trie.svg
 [coveralls_link]: https://coveralls.io/r/gonzedge/rambling-trie
+[downloads_badge]: https://img.shields.io/gem/dt/rambling-trie.svg
+[downloads_link]: https://rubygems.org/gems/rambling-trie
 [gemnasium_badge]: https://gemnasium.com/gonzedge/rambling-trie.svg
 [gemnasium_link]: https://gemnasium.com/gonzedge/rambling-trie
 [github_user_gonzedge]: https://github.com/gonzedge

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 [github_user_gonzedge]: https://github.com/gonzedge
 [inch_ci_badge]: https://inch-ci.org/github/gonzedge/rambling-trie.svg?branch=master
 [inch_ci_link]: http://rubydoc.info/gems/rambling-trie
-[license_badge]: https://badges.frapsoft.com/os/mit/mit.svg?v=103
+[license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license_link]: https://opensource.org/licenses/mit-license.php
 [marshal]: https://ruby-doc.org/core-2.7.0/Marshal.html
 [rambling_trie_configuration]: https://github.com/gonzedge/rambling-trie#configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Rambling Trie
 
-[![Gem Version][badge_fury_badge]][badge_fury_link] [![Build Status][semaphore_ci_badge]][semaphore_ci_link] [![Code Climate][code_climate_badge]][code_climage_link] [![Coverage Status][coveralls_badge]][coveralls_link] [![Documentation Status][inch_ci_badge]][inch_ci_link] [![License][license_badge]][license_link]
+[![Gem Version][badge_fury_badge]][badge_fury_link]
+[![Build Status][semaphore_ci_badge]][semaphore_ci_link]
+[![Code Climate][code_climate_badge]][code_climage_link]
+[![Coverage Status][coveralls_badge]][coveralls_link]
+[![Documentation Status][inch_ci_badge]][inch_ci_link]
+[![License][license_badge]][license_link]
 
 The Rambling Trie is a Ruby implementation of the [trie data structure][trie_wiki], which includes compression abilities and is designed to be very fast to traverse.
 


### PR DESCRIPTION
* Update `.coveralls.yml` to point to `semaphore`
* On `.semaphore/semaphore.yml`:
    * Rename pipeline to `Run specs in all supported rubies'
    * Extract `checkout` command to `global_job_config.prologue`
    * Add `3.2.2`, `3.1.4`, `3.0.6`, `2.7.8` tasks
    * Correctly configure main `3.2.2` task to publish test report, now being picked up by Semaphore 
![Screenshot 2023-05-09 at 4 55 13 PM](https://github.com/gonzedge/rambling-trie/assets/218312/de876e83-f569-48b9-b2f1-4a33c8c166c5)
    * Remove unnecessary formatters from non-`3.2.2` tasks
* On badges:
    * Change `README.md` to have one badge per line instead of all in one giant line
    * Add RubyGems downloads badge
    * Add CodeClimate issues badge
    * Update docs badge to point directly to [rubydoc.info/gems/rambling-trie](http://rubydoc.info/gems/rambling-trie)
    * Update license badge to one from shields.io