### PR TITLE
Ensure all serializer #dump methods return the size of the file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Vim
+# Vim / IDEs
 *.swp
 *.swo
+.idea/
 
 # RVM
 .rvmrc

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -50,6 +50,8 @@ module Rambling
 
             zip.add filename, entry_path
           end
+
+          ::File.size filepath
         end
 
         private

--- a/spec/support/shared_examples/a_serializer.rb
+++ b/spec/support/shared_examples/a_serializer.rb
@@ -16,17 +16,22 @@ shared_examples_for 'a serializer' do
   describe '#dump' do
     [true, false].each do |compress_value|
       context "with compressed=#{compress_value} trie" do
-        before do
-          trie.compress! if compress_value
-          serializer.dump content, filepath
+        let(:formatted_content) { format_content.call content }
+
+        before { trie.compress! if compress_value }
+
+        it 'returns the size in bytes of the file dumped' do
+          total_bytes = serializer.dump content, filepath
+          expect(total_bytes).to be_within(20).of formatted_content.size
         end
 
         it 'creates the file with the provided path' do
+          serializer.dump content, filepath
           expect(File.exist? filepath).to be true
         end
 
         it 'converts the contents to the appropriate format' do
-          formatted_content = format_content.call content
+          serializer.dump content, filepath
           expect(File.size filepath).to be_within(20).of formatted_content.size
         end
       end


### PR DESCRIPTION
- Add test in `a serializer` shared examples
- Implement method for `Rambling::Trie::Serializers::Zip`