### PR TITLE
Improve API documentation

### DIFF
--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -13,7 +13,7 @@ module Rambling
   # Entry point for +rambling-trie+ API.
   module Trie
     class << self
-      # Creates a new +Rambling::Trie+. Entry point for the +Rambling::Trie+ API.
+      # Creates a new +Rambling::Trie+. Entry point for the +rambling-trie+ API.
       # @param [String, nil] filepath the file to load the words from.
       # @param [Readers::Reader, nil] reader the file parser to get each word.
       # @return [Container] the trie just created.

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -10,12 +10,12 @@ end
 
 # General namespace for all Rambling gems.
 module Rambling
-  # Entry point for rambling-trie API.
+  # Entry point for +rambling-trie+ API.
   module Trie
     class << self
-      # Creates a new Rambling::Trie. Entry point for the Rambling::Trie API.
+      # Creates a new +Rambling::Trie+. Entry point for the +Rambling::Trie+ API.
       # @param [String, nil] filepath the file to load the words from.
-      # @param [Reader, nil] reader the file parser to get each word.
+      # @param [Readers::Reader, nil] reader the file parser to get each word.
       # @return [Container] the trie just created.
       # @yield [Container] the trie just created.
       # @see Rambling::Trie::Readers Readers.
@@ -36,7 +36,7 @@ module Rambling
 
       # Loads an existing trie from disk into memory. By default, it will
       # deduce the correct way to deserialize based on the file extension.
-      # Available formats are `yml`, `marshal`, and `zip` versions of all the
+      # Available formats are +yml+, +marshal+, and +zip+ versions of all the
       # previous formats. You can also define your own.
       # @param [String] filepath the file to load the words from.
       # @param [Serializer, nil] serializer the object responsible of loading
@@ -46,7 +46,7 @@ module Rambling
       # @see Rambling::Trie::Serializers Serializers.
       # @note Use of
       #   {https://ruby-doc.org/core-2.7.0/Marshal.html#method-c-load
-      #   Marshal.load} is generally discouraged. Only use the `.marshal`
+      #   Marshal.load} is generally discouraged. Only use the +.marshal+
       #   format with trusted input.
       def load filepath, serializer = nil
         serializer ||= serializers.resolve filepath
@@ -58,19 +58,21 @@ module Rambling
 
       # Dumps an existing trie from memory into disk. By default, it will
       # deduce the correct way to serialize based on the file extension.
-      # Available formats are `yml`, `marshal`, and `zip` versions of all the
+      # Available formats are +yml+, +marshal+, and +zip+ versions of all the
       # previous formats. You can also define your own.
       # @param [Container] trie the trie to dump into disk.
       # @param [String] filepath the file to dump to serialized trie into.
-      # @param [Serializer, nil] serializer the object responsible of
+      # @param [Serializers::Serializer, nil] serializer the object responsible
+      #   for trie serialization.
+      # @return [void]
       #   serializing and dumping the trie into disk.
-      # @see Rambling::Trie::Serializers Serializers.
+      # @see Serializers Serializers.
       def dump trie, filepath, serializer = nil
         serializer ||= serializers.resolve filepath
         serializer.dump trie.root, filepath
       end
 
-      # Provides configuration properties for the Rambling::Trie gem.
+      # Provides configuration properties for the +Rambling::Trie+ gem.
       # @return [Configuration::Properties] the configured properties of the
       #   gem.
       # @yield [Configuration::Properties] the configured properties of the

--- a/lib/rambling/trie/comparable.rb
+++ b/lib/rambling/trie/comparable.rb
@@ -6,8 +6,8 @@ module Rambling
     module Comparable
       # Compares two nodes.
       # @param [Nodes::Node] other the node to compare against.
-      # @return [Boolean] `true` if the nodes' {Nodes::Node#letter #letter} and
-      #   {Nodes::Node#children_tree #children_tree} are equal, `false`
+      # @return [Boolean] +true+ if the nodes' {Nodes::Node#letter #letter} and
+      #   {Nodes::Node#children_tree #children_tree} are equal, +false+
       #   otherwise.
       def == other
         letter == other.letter &&

--- a/lib/rambling/trie/compressible.rb
+++ b/lib/rambling/trie/compressible.rb
@@ -6,8 +6,8 @@ module Rambling
     module Compressible
       # Indicates if the current {Rambling::Trie::Nodes::Node Node} can be
       # compressed or not.
-      # @return [Boolean] `true` for non-{Nodes::Node#terminal? terminal} nodes
-      #   with one child, `false` otherwise.
+      # @return [Boolean] +true+ for non-{Nodes::Node#terminal? terminal} nodes
+      #   with one child, +false+ otherwise.
       def compressible?
         !(root? || terminal?) && 1 == children_tree.size
       end

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -6,13 +6,13 @@ module Rambling
       # Provides configurable properties for Rambling::Trie.
       class Properties
         # The configured {Readers Readers}.
-        # @return [ProviderCollection] the mapping of configured {Readers
-        #   Readers}.
+        # @return [ProviderCollection<Readers::Reader>] the mapping of
+        #   configured {Readers Readers}.
         attr_reader :readers
 
         # The configured {Serializers Serializers}.
-        # @return [ProviderCollection] the mapping of configured {Serializers
-        #   Serializers}.
+        # @return [ProviderCollection<Serializers::Serializer>] the mapping of
+        #   configured {Serializers Serializers}.
         attr_reader :serializers
 
         # The configured {Compressor Compressor}.

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -19,7 +19,7 @@ module Rambling
         # @return [Compressor] the configured compressor.
         attr_accessor :compressor
 
-        # The configured +root_builder+, which should return a {Nodes::Node Node}
+        # The configured +root_builder+, which returns a {Nodes::Node Node}
         # when called.
         # @return [Proc<Nodes::Node>] the configured +root_builder+.
         attr_accessor :root_builder

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -34,6 +34,7 @@ module Rambling
         end
 
         # Resets back to default properties.
+        # @return [void]
         def reset
           reset_readers
           reset_serializers

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -19,13 +19,13 @@ module Rambling
         # @return [Compressor] the configured compressor.
         attr_accessor :compressor
 
-        # The configured root_builder, which should return a {Nodes::Node Node}
-        #   when called.
-        # @return [Proc<Nodes::Node>] the configured root_builder.
+        # The configured +root_builder+, which should return a {Nodes::Node Node}
+        # when called.
+        # @return [Proc<Nodes::Node>] the configured +root_builder+.
         attr_accessor :root_builder
 
-        # The configured tmp_path, which will be used for throwaway files.
-        # @return [String] the configured tmp_path.
+        # The configured +tmp_path+, which will be used for throwaway files.
+        # @return [String] the configured +tmp_path+.
         attr_accessor :tmp_path
 
         # Returns a new properties instance.

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -6,7 +6,7 @@ module Rambling
       # Collection of configurable providers.
       class ProviderCollection
         # The name of this provider collection.
-        # @return [String] the name of this provider collection.
+        # @return [Symbol] the name of this provider collection.
         attr_reader :name
 
         # @overload default
@@ -15,18 +15,18 @@ module Rambling
         # @overload default=(provider)
         #   Sets the default provider. Needs to be one of the configured
         #   providers.
-        #   @param [Object] provider the provider to use as default.
+        #   @param [TProvider] provider the provider to use as default.
         #   @raise [ArgumentError] when the given provider is not in the
         #     provider collection.
         #   @note If no providers have been configured, `nil` will be assigned.
-        # @return [Object, nil] the default provider to use when a provider
+        # @return [TProvider, nil] the default provider to use when a provider
         #   cannot be resolved in {ProviderCollection#resolve #resolve}.
         attr_reader :default
 
         # Creates a new provider collection.
-        # @param [String] name the name for this provider collection.
-        # @param [Hash] providers the configured providers.
-        # @param [Object] default the configured default provider.
+        # @param [Symbol] name the name for this provider collection.
+        # @param [Hash<Symbol, TProvider>] providers the configured providers.
+        # @param [TProvider, nil] default the configured default provider.
         def initialize name, providers = {}, default = nil
           @name = name
           @configured_providers = providers
@@ -54,16 +54,16 @@ module Rambling
         end
 
         # List of configured providers.
-        # @return [Hash] the mapping of extensions to their corresponding
-        #   providers.
+        # @return [Hash<Symbol, TProvider>] the mapping of extensions to their
+        #   corresponding providers.
         def providers
           @providers ||= {}
         end
 
         # Resolves the provider from a filepath based on the file extension.
         # @param [String] filepath the filepath to resolve into a provider.
-        # @return [Object] the provider corresponding to the file extension in
-        #   this provider collection. {#default} if not found.
+        # @return [TProvider, nil] the provider corresponding to the file extension
+        #   in provider collection. {#default} if not found.
         def resolve filepath
           providers[file_format filepath] || default
         end
@@ -85,7 +85,7 @@ module Rambling
 
         # Get provider corresponding to a given format.
         # @param [Symbol] format the format to search for in the collection.
-        # @return [Object] the provider corresponding to that format.
+        # @return [TProvider] the provider corresponding to that format.
         # @see https://ruby-doc.org/core-2.7.0/Hash.html#method-i-5B-5D
         #   Hash#[]
         def [] format

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -38,8 +38,9 @@ module Rambling
         # Adds a new provider to the provider collection.
         # @param [Symbol] extension the extension that the provider will
         #   correspond to.
-        # @param [provider] provider the provider to add to the provider
+        # @param [TProvider] provider the provider to add to the provider
         #   collection.
+        # @return [TProvider] the provider just added.
         def add extension, provider
           providers[extension] = provider
         end

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -18,7 +18,7 @@ module Rambling
         #   @param [TProvider] provider the provider to use as default.
         #   @raise [ArgumentError] when the given provider is not in the
         #     provider collection.
-        #   @note If no providers have been configured, `nil` will be assigned.
+        #   @note If no providers have been configured, +nil+ will be assigned.
         # @return [TProvider, nil] the default provider to use when a provider
         #   cannot be resolved in {ProviderCollection#resolve #resolve}.
         attr_reader :default

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -69,6 +69,7 @@ module Rambling
         end
 
         # Resets the provider collection to the initial values.
+        # @return [void]
         def reset
           providers.clear
           configured_providers.each { |k, v| self[k] = v }

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -63,8 +63,8 @@ module Rambling
 
         # Resolves the provider from a filepath based on the file extension.
         # @param [String] filepath the filepath to resolve into a provider.
-        # @return [TProvider, nil] the provider corresponding to the file extension
-        #   in provider collection. {#default} if not found.
+        # @return [TProvider, nil] the provider for the given file's extension.
+        #   {#default} if not found.
         def resolve filepath
           providers[file_format filepath] || default
         end

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -13,7 +13,7 @@ module Rambling
       # Creates a new trie.
       # @param [Nodes::Node] root the root node for the trie
       # @param [Compressor] compressor responsible for compressing the trie
-      # @yield [Container] the trie just created.
+      # @yield [self] the trie just initialized.
       def initialize root, compressor
         @root = root
         @compressor = compressor
@@ -44,7 +44,7 @@ module Rambling
       # Compresses the existing trie using redundant node elimination. Marks
       # the trie as compressed. Does nothing if the trie has already been
       # compressed.
-      # @return [Container] self
+      # @return [self]
       # @note This method replaces the root {Nodes::Raw Raw} node with a
       #   {Nodes::Compressed Compressed} version of it.
       def compress!
@@ -113,13 +113,14 @@ module Rambling
 
       # Compares two trie data structures.
       # @param [Container] other the trie to compare against.
-      # @return [Boolean] `true` if the tries are equal, `false` otherwise.
+      # @return [Boolean] +true+ if the tries are equal, +false+ otherwise.
       def == other
         root == other.root
       end
 
       # Iterates over the words contained in the trie.
       # @yield [String] the words contained in this trie node.
+      # @return [self]
       def each
         return enum_for :each unless block_given?
 

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -67,8 +67,7 @@ module Rambling
       # @param [String] word the word or partial word to look for in the trie.
       # @return [Boolean] +true+ if the word or partial word is found, +false+
       #   otherwise.
-      # @see Nodes::Raw#partial_word?
-      # @see Nodes::Compressed#partial_word?
+      # @see Nodes::Node#partial_word?
       def partial_word? word = ''
         root.partial_word? word.chars
       end
@@ -86,8 +85,7 @@ module Rambling
       # @param [String] word the word to look for in the trie.
       # @return [Array<String>] all the words contained in the trie that start
       #   with the specified characters.
-      # @see Nodes::Raw#scan
-      # @see Nodes::Compressed#scan
+      # @see Nodes::Node#scan
       def scan word = ''
         root.scan(word.chars).to_a
       end
@@ -151,8 +149,8 @@ module Rambling
       end
 
       # Root node's children tree.
-      # @return [Array<Nodes::Node>] the array of children nodes contained in
-      #   the root node.
+      # @return [Hash<Symbol, Nodes::Node>] the children tree hash, consisting of
+      #   +:letter => node+.
       # @see Nodes::Node#children_tree
       def children_tree
         root.children_tree

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -149,8 +149,8 @@ module Rambling
       end
 
       # Root node's children tree.
-      # @return [Hash<Symbol, Nodes::Node>] the children tree hash, consisting of
-      #   +:letter => node+.
+      # @return [Hash<Symbol, Nodes::Node>] the children tree hash contained in
+      #   the root node, consisting of +:letter => node+.
       # @see Nodes::Node#children_tree
       def children_tree
         root.children_tree

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -65,7 +65,7 @@ module Rambling
 
       # Checks if a path for a word or partial word exists in the trie.
       # @param [String] word the word or partial word to look for in the trie.
-      # @return [Boolean] `true` if the word or partial word is found, `false`
+      # @return [Boolean] +true+ if the word or partial word is found, +false+
       #   otherwise.
       # @see Nodes::Raw#partial_word?
       # @see Nodes::Compressed#partial_word?
@@ -75,10 +75,9 @@ module Rambling
 
       # Checks if a whole word exists in the trie.
       # @param [String] word the word to look for in the trie.
-      # @return [Boolean] `true` only if the word is found and the last
-      #   character corresponds to a terminal node, `false` otherwise.
-      # @see Nodes::Raw#word?
-      # @see Nodes::Compressed#word?
+      # @return [Boolean] +true+ only if the word is found and the last
+      #   character corresponds to a terminal node, +false+ otherwise.
+      # @see Nodes::Node#word?
       def word? word = ''
         root.word? word.chars
       end
@@ -99,15 +98,14 @@ module Rambling
       # @return [Enumerator<String>] all the words in the given string that
       #   match a word in the trie.
       # @yield [String] each word found in phrase.
-      # @see Nodes::Node#words_within
       def words_within phrase
         words_within_root(phrase).to_a
       end
 
       # Checks if there are any valid words in a given string.
       # @param [String] phrase the string to look for matching words in.
-      # @return [Boolean] `true` if any word within phrase is contained in the
-      #   trie, `false` otherwise.
+      # @return [Boolean] +true+ if any word within phrase is contained in the
+      #   trie, +false+ otherwise.
       # @see Container#words_within
       def words_within? phrase
         words_within_root(phrase).any?
@@ -161,8 +159,8 @@ module Rambling
 
       # Indicates if the root {Nodes::Node Node} can be
       # compressed or not.
-      # @return [Boolean] `true` for non-{Nodes::Node#terminal? terminal}
-      #    nodes with one child, `false` otherwise.
+      # @return [Boolean] +true+ for non-{Nodes::Node#terminal? terminal}
+      #    nodes with one child, +false+ otherwise.
       def compressed?
         root.compressed?
       end

--- a/lib/rambling/trie/enumerable.rb
+++ b/lib/rambling/trie/enumerable.rb
@@ -13,6 +13,7 @@ module Rambling
 
       # Iterates over the words contained in the trie.
       # @yield [String] the words contained in this trie node.
+      # @return [self]
       def each
         return enum_for :each unless block_given?
 

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -15,8 +15,8 @@ module Rambling
             'Cannot add word to compressed trie'
         end
 
-        # Always return `true` for a compressed node.
-        # @return [Boolean] always `true` for a compressed node.
+        # Always return +true+ for a compressed node.
+        # @return [Boolean] always +true+ for a compressed node.
         def compressed?
           true
         end

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -9,7 +9,7 @@ module Rambling
         # trying to add a word to the current compressed trie node
         # @param [String] _ the word to add to the trie.
         # @raise [InvalidOperation] if the trie is already compressed.
-        # @return [nil] this never returns as it always raises an exception.
+        # @return [void]
         def add _
           raise Rambling::Trie::InvalidOperation,
             'Cannot add word to compressed trie'

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -31,7 +31,7 @@ module Rambling
         attr_accessor :parent
 
         # Creates a new node.
-        # @param [Symbol, nil] letter the Node's letter value
+        # @param [Symbol, nil] letter the Node's letter value.
         # @param [Node, nil] parent the parent of the current node.
         def initialize letter = nil, parent = nil, children_tree = {}
           @letter = letter
@@ -40,7 +40,7 @@ module Rambling
         end
 
         # Child nodes.
-        # @return [Array<Node>] the array of children nodes contained
+        # @return [Array<Node>] the array of child nodes contained
         #   in the current node.
         def children
           children_tree.values
@@ -156,7 +156,7 @@ module Rambling
         end
 
         # Delete a given letter and its corresponding {Node Node} from
-        #   this {Node Node}'s children tree.
+        # this {Node Node}'s children tree.
         # @param [Symbol] letter the letter to delete from the node's children
         #   tree.
         # @return [Node] the node corresponding to the deleted letter.

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -22,8 +22,8 @@ module Rambling
         attr_reader :letter
 
         # Child nodes tree.
-        # @return [Hash] the children_tree hash, consisting of `:letter =>
-        #   node`.
+        # @return [Hash<Symbol, Node>] the children_tree hash, consisting of
+        #   `:letter => node`.
         attr_accessor :children_tree
 
         # Parent node.

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -22,8 +22,8 @@ module Rambling
         attr_reader :letter
 
         # Child nodes tree.
-        # @return [Hash<Symbol, Node>] the children_tree hash, consisting of
-        #   `:letter => node`.
+        # @return [Hash<Symbol, Node>] the children tree hash, consisting of
+        #   +:letter => node+.
         attr_accessor :children_tree
 
         # Parent node.
@@ -57,14 +57,14 @@ module Rambling
         end
 
         # Indicates if the current node is the root node.
-        # @return [Boolean] `true` if the node does not have a parent, `false`
+        # @return [Boolean] +true+ if the node does not have a parent, +false+
         #   otherwise.
         def root?
           !parent
         end
 
         # Indicates if a {Node Node} is terminal or not.
-        # @return [Boolean] `true` for terminal nodes, `false` otherwise.
+        # @return [Boolean] +true+ for terminal nodes, +false+ otherwise.
         def terminal?
           !!terminal
         end
@@ -82,7 +82,7 @@ module Rambling
 
         # Checks if a path for a set of characters exists in the trie.
         # @param [Array<String>] chars the characters to look for in the trie.
-        # @return [Boolean] `true` if the characters are found, `false`
+        # @return [Boolean] +true+ if the characters are found, +false+
         #   otherwise.
         def partial_word? chars
           return true if chars.empty?
@@ -92,8 +92,8 @@ module Rambling
 
         # Checks if a path for set of characters represents a word in the trie.
         # @param [Array<String>] chars the characters to look for in the trie.
-        # @return [Boolean] `true` if the characters are found and form a word,
-        #   `false` otherwise.
+        # @return [Boolean] +true+ if the characters are found and form a word,
+        #   +false+ otherwise.
         def word? chars = []
           return terminal? if chars.empty?
 
@@ -148,7 +148,7 @@ module Rambling
         # Check if a {Node Node}'s children tree contains a given
         #   letter.
         # @param [Symbol] letter the letter to search for in the node.
-        # @return [Boolean] `true` if the letter is present, `false` otherwise
+        # @return [Boolean] +true+ if the letter is present, +false+ otherwise.
         # @see https://ruby-doc.org/core-2.7.0/Hash.html#method-i-has_key-3F
         #   Hash#key?
         def key? letter

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -17,8 +17,8 @@ module Rambling
           end
         end
 
-        # Always return `false` for a raw (uncompressed) node.
-        # @return [Boolean] always `false` for a raw (uncompressed) node.
+        # Always return +false+ for a raw (uncompressed) node.
+        # @return [Boolean] always +false+ for a raw (uncompressed) node.
         def compressed?
           false
         end

--- a/lib/rambling/trie/readers.rb
+++ b/lib/rambling/trie/readers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-%w(plain_text).each do |file|
+%w(reader plain_text).each do |file|
   require File.join('rambling', 'trie', 'readers', file)
 end
 

--- a/lib/rambling/trie/readers/plain_text.rb
+++ b/lib/rambling/trie/readers/plain_text.rb
@@ -3,9 +3,9 @@
 module Rambling
   module Trie
     module Readers
-      # File reader for .txt files.
+      # File reader for +.txt+ files.
       class PlainText < Reader
-        # Yields each word read from a .txt file.
+        # Yields each word read from a +.txt+ file.
         # @param [String] filepath the full path of the file to load the words
         #   from.
         # @yield [String] Each line read from the file.

--- a/lib/rambling/trie/readers/plain_text.rb
+++ b/lib/rambling/trie/readers/plain_text.rb
@@ -9,6 +9,7 @@ module Rambling
         # @param [String] filepath the full path of the file to load the words
         #   from.
         # @yield [String] Each line read from the file.
+        # @return [self]
         def each_word filepath
           return enum_for :each_word unless block_given?
 

--- a/lib/rambling/trie/readers/plain_text.rb
+++ b/lib/rambling/trie/readers/plain_text.rb
@@ -4,7 +4,7 @@ module Rambling
   module Trie
     module Readers
       # File reader for .txt files.
-      class PlainText
+      class PlainText < Reader
         # Yields each word read from a .txt file.
         # @param [String] filepath the full path of the file to load the words
         #   from.

--- a/lib/rambling/trie/readers/reader.rb
+++ b/lib/rambling/trie/readers/reader.rb
@@ -11,6 +11,7 @@ module Rambling
         # @param [String] filepath the full path of the file to load the words
         #   from.
         # @yield [String] Each line read from the file.
+        # @return [self]
         def each_word filepath
           raise NotImplementedError
         end

--- a/lib/rambling/trie/readers/reader.rb
+++ b/lib/rambling/trie/readers/reader.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Rambling
+  module Trie
+    module Readers
+      # Base class for all readers.
+      class Reader
+        # Yields each word read from given file.
+        # @abstract Subclass and override {#each_word} to fit to a particular
+        #   file format.
+        # @param [String] filepath the full path of the file to load the words
+        #   from.
+        # @yield [String] Each line read from the file.
+        def each_word filepath
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/rambling/trie/serializers.rb
+++ b/lib/rambling/trie/serializers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-%w(file marshal yaml zip).each do |file|
+%w(serializer file marshal yaml zip).each do |file|
   require File.join('rambling', 'trie', 'serializers', file)
 end
 

--- a/lib/rambling/trie/serializers/file.rb
+++ b/lib/rambling/trie/serializers/file.rb
@@ -4,7 +4,7 @@ module Rambling
   module Trie
     module Serializers
       # Basic file serializer. Dumps/loads string contents from files.
-      class File
+      class File < Serializer
         # Loads contents from a specified filepath.
         # @param [String] filepath the filepath to load contents from.
         # @return [String] all contents of the file.

--- a/lib/rambling/trie/serializers/marshal.rb
+++ b/lib/rambling/trie/serializers/marshal.rb
@@ -3,7 +3,7 @@
 module Rambling
   module Trie
     module Serializers
-      # Serializer for Ruby marshal format (.marshal) files.
+      # Serializer for Ruby marshal format (+.marshal+) files.
       class Marshal < Serializer
         # Creates a new Marshal serializer.
         # @param [Serializer] serializer the serializer responsible to write to

--- a/lib/rambling/trie/serializers/marshal.rb
+++ b/lib/rambling/trie/serializers/marshal.rb
@@ -4,12 +4,13 @@ module Rambling
   module Trie
     module Serializers
       # Serializer for Ruby marshal format (.marshal) files.
-      class Marshal
+      class Marshal < Serializer
         # Creates a new Marshal serializer.
         # @param [Serializer] serializer the serializer responsible to write to
         #   and read from disk.
         def initialize serializer = nil
           @serializer = serializer || Rambling::Trie::Serializers::File.new
+          super()
         end
 
         # Loads marshaled object from contents in filepath and deserializes it

--- a/lib/rambling/trie/serializers/serializer.rb
+++ b/lib/rambling/trie/serializers/serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Rambling
+  module Trie
+    module Serializers
+      # Base class for all serializers.
+      class Serializer
+        # Loads contents from a specified filepath.
+        # @abstract Subclass and override {#load} to parse the desired format.
+        # @param [String] filepath the filepath to load contents from.
+        # @return [TContents] parsed contents from given file.
+        def load filepath
+          raise NotImplementedError
+        end
+
+        # Dumps contents into a specified filepath.
+        # @abstract Subclass and override {#dump} to output the desired format.
+        # @param [TContents] contents the contents to dump into given file.
+        # @param [String] filepath the filepath to dump the contents to.
+        # @return [Numeric] number of bytes written to disk.
+        def dump contents, filepath
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/rambling/trie/serializers/yaml.rb
+++ b/lib/rambling/trie/serializers/yaml.rb
@@ -3,7 +3,7 @@
 module Rambling
   module Trie
     module Serializers
-      # Serializer for Ruby yaml format (.yaml) files.
+      # Serializer for Ruby yaml format (+.yaml+, or +.yml+) files.
       class Yaml < Serializer
         # Creates a new Yaml serializer.
         # @param [Serializer] serializer the serializer responsible to write to

--- a/lib/rambling/trie/serializers/yaml.rb
+++ b/lib/rambling/trie/serializers/yaml.rb
@@ -4,12 +4,13 @@ module Rambling
   module Trie
     module Serializers
       # Serializer for Ruby yaml format (.yaml) files.
-      class Yaml
+      class Yaml < Serializer
         # Creates a new Yaml serializer.
         # @param [Serializer] serializer the serializer responsible to write to
         #   and read from disk.
         def initialize serializer = nil
           @serializer = serializer || Rambling::Trie::Serializers::File.new
+          super()
         end
 
         # Loads serialized object from YAML file in filepath and deserializes

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -3,8 +3,9 @@
 module Rambling
   module Trie
     module Serializers
-      # Zip file serializer. Dumps/loads contents from zip files. Automatically
-      # detects if zip file contains `.marshal` or `.yml` file
+      # Zip file serializer. Dumps/loads contents from +.zip+ files.
+      # Automatically detects if zip file contains a +.marshal+ or +.yml+ file,
+      # or any other registered +:format => serializer+ combo.
       class Zip < Serializer
         # Creates a new Zip serializer.
         # @param [Configuration::Properties] properties the configuration

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -5,12 +5,13 @@ module Rambling
     module Serializers
       # Zip file serializer. Dumps/loads contents from zip files. Automatically
       # detects if zip file contains `.marshal` or `.yml` file
-      class Zip
+      class Zip < Serializer
         # Creates a new Zip serializer.
         # @param [Configuration::Properties] properties the configuration
         #   properties set up so far.
         def initialize properties
           @properties = properties
+          super()
         end
 
         # Unzip contents from specified filepath and load in contents from

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -18,7 +18,7 @@ module Rambling
         # Unzip contents from specified filepath and load in contents from
         # unzipped files.
         # @param [String] filepath the filepath to load contents from.
-        # @return [String] all contents of the unzipped loaded file.
+        # @return [TContents] all contents of the unzipped loaded file.
         # @see https://github.com/rubyzip/rubyzip#reading-a-zip-file Zip
         #   reading a file
         def load filepath
@@ -37,7 +37,7 @@ module Rambling
         # Dumps contents and zips into a specified filepath.
         # @param [String] contents the contents to dump.
         # @param [String] filepath the filepath to dump the contents to.
-        # @return [Numeric] number of bytes written to disk.
+        # @return [TContents] number of bytes written to disk.
         # @see https://github.com/rubyzip/rubyzip#basic-zip-archive-creation
         #   Zip archive creation
         def dump contents, filepath

--- a/lib/rambling/trie/stringifyable.rb
+++ b/lib/rambling/trie/stringifyable.rb
@@ -2,7 +2,7 @@
 
 module Rambling
   module Trie
-    # Provides the String representation behavior for the trie data structure.
+    # Provides the +String+ representation behavior for the trie data structure.
     module Stringifyable
       # String representation of the current node, if it is a terminal node.
       # @return [String] the string representation of the current node.

--- a/spec/lib/rambling/trie/readers/reader_spec.rb
+++ b/spec/lib/rambling/trie/readers/reader_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Rambling::Trie::Readers::Reader do
+  subject(:reader) { described_class.new }
+
+  describe '#load' do
+    it 'is an abstract method that raises NotImplementedError' do
+      expect { reader.each_word('any-file.zip') }
+        .to raise_exception NotImplementedError
+    end
+  end
+end

--- a/spec/lib/rambling/trie/serializers/serializer_spec.rb
+++ b/spec/lib/rambling/trie/serializers/serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Rambling::Trie::Serializers::Serializer do
+  subject(:serializer) { described_class.new }
+
+  describe '#load' do
+    it 'is an abstract method that raises NotImplementedError' do
+      expect { serializer.load('any-file.zip') }
+        .to raise_exception NotImplementedError
+    end
+  end
+
+  describe '#dump' do
+    it 'is an abstract method that raises NotImplementedError' do
+      expect { serializer.dump('any contents', 'any-file.zip') }
+        .to raise_exception NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
- Add `Readers::Reader` and `Serializer::Serializer` base classes 
- Make all readers/serializers extend from their corresponding base classes
- Better docs with `Reader`/`Serializer` and generics
- Fix all code blocks from `\`` to `+` and add some more
- Add `@return [void]` where appropriate
- Add `@return [self]` where appropriate
- Fix `Nodes::Node` duplicate and broken references
- Fix some typos and add some missing periods
