### PR TITLE
Use `RSpec::Config`'s `filter_run_when_matching`

### DIFF
--- a/spec/integration/rambling/trie_spec.rb
+++ b/spec/integration/rambling/trie_spec.rb
@@ -18,7 +18,7 @@ describe Rambling::Trie do
   context 'when provided with words with unicode characters' do
     it_behaves_like 'a compressible trie' do
       let(:trie) { described_class.create }
-      let(:words) do
+      let :words do
         %w(poquísimas palabras para nuestra prueba de integración completa 🙃)
       end
 

--- a/spec/integration/rambling/trie_spec.rb
+++ b/spec/integration/rambling/trie_spec.rb
@@ -50,14 +50,14 @@ describe Rambling::Trie do
     context 'when serialized with Ruby marshal format (default)' do
       it_behaves_like 'a serializable trie' do
         let(:trie_to_serialize) { described_class.create words_filepath }
-        let(:format) { :marshal }
+        let(:file_format) { :marshal }
       end
     end
 
     context 'when serialized with YAML' do
       it_behaves_like 'a serializable trie' do
         let(:trie_to_serialize) { described_class.create words_filepath }
-        let(:format) { :yml }
+        let(:file_format) { :yml }
       end
     end
 
@@ -77,7 +77,7 @@ describe Rambling::Trie do
 
       it_behaves_like 'a serializable trie' do
         let(:trie_to_serialize) { described_class.create words_filepath }
-        let(:format) { 'marshal.zip' }
+        let(:file_format) { 'marshal.zip' }
       end
     end
   end

--- a/spec/lib/rambling/trie/configuration/provider_collection_spec.rb
+++ b/spec/lib/rambling/trie/configuration/provider_collection_spec.rb
@@ -4,18 +4,18 @@ require 'spec_helper'
 
 describe Rambling::Trie::Configuration::ProviderCollection do
   let(:configured_default) { nil }
-  let(:configured_providers) do
+  let :configured_providers do
     { one: first_provider, two: second_provider }
   end
 
-  let(:first_provider) do
+  let :first_provider do
     instance_double 'Rambling::Trie::Serializers::Marshal', :first_provider
   end
-  let(:second_provider) do
+  let :second_provider do
     instance_double 'Rambling::Trie::Serializers::Marshal', :second_provider
   end
 
-  let(:provider_collection) do
+  let :provider_collection do
     described_class.new(
       :provider,
       configured_providers,
@@ -72,7 +72,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
   end
 
   describe '#add' do
-    let(:provider) do
+    let :provider do
       instance_double 'Rambling::Trie::Serializers::Marshal', :provider
     end
 
@@ -86,7 +86,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
   end
 
   describe '#default=' do
-    let(:other_provider) do
+    let :other_provider do
       instance_double 'Rambling::Trie::Serializers::Marshal', :other_provider
     end
 
@@ -155,7 +155,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
 
   describe '#reset' do
     let(:configured_default) { second_provider }
-    let(:provider) do
+    let :provider do
       instance_double 'Rambling::Trie::Serializers::Marshal', :provider
     end
 

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -329,7 +329,7 @@ describe Rambling::Trie::Container do
 
   describe '#==' do
     context 'when the root nodes are the same' do
-      let(:other_container) do
+      let :other_container do
         described_class.new container.root, compressor
       end
 
@@ -340,7 +340,7 @@ describe Rambling::Trie::Container do
 
     context 'when the root nodes are not the same' do
       let(:other_root) { Rambling::Trie::Nodes::Raw.new }
-      let(:other_container) do
+      let :other_container do
         described_class.new other_root, compressor
       end
 

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -171,7 +171,7 @@ describe Rambling::Trie::Container do
 
   describe '#word?' do
     it_behaves_like 'a propagating node' do
-      let(:method) { :word? }
+      let(:method_name) { :word? }
     end
 
     context 'when word is contained' do
@@ -202,7 +202,7 @@ describe Rambling::Trie::Container do
   describe '#partial_word?' do
     context 'with underlying node' do
       it_behaves_like 'a propagating node' do
-        let(:method) { :partial_word? }
+        let(:method_name) { :partial_word? }
       end
     end
 

--- a/spec/lib/rambling/trie/nodes/compressed_spec.rb
+++ b/spec/lib/rambling/trie/nodes/compressed_spec.rb
@@ -7,6 +7,12 @@ describe Rambling::Trie::Nodes::Compressed do
   let(:compressor) { Rambling::Trie::Compressor.new }
   let(:node) { compressor.compress raw_node }
 
+  describe '#new' do
+    it 'is not a word' do
+      expect(node).not_to be_word
+    end
+  end
+
   it_behaves_like 'a trie node implementation' do
     def add_word_to_tree word
       add_word raw_node, word

--- a/spec/lib/rambling/trie/nodes/raw_spec.rb
+++ b/spec/lib/rambling/trie/nodes/raw_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 describe Rambling::Trie::Nodes::Raw do
   let(:node) { described_class.new }
 
+  describe '#new' do
+    it 'is not a word' do
+      expect(node).not_to be_word
+    end
+  end
+
   it_behaves_like 'a trie node implementation' do
     def add_word_to_tree word
       add_word node, word
@@ -16,10 +22,6 @@ describe Rambling::Trie::Nodes::Raw do
 
     def assign_letter letter
       node.letter = letter
-    end
-
-    it 'is not a word' do
-      expect(node).not_to be_word
     end
   end
 

--- a/spec/lib/rambling/trie/serializers/file_spec.rb
+++ b/spec/lib/rambling/trie/serializers/file_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::File do
   it_behaves_like 'a serializer' do
-    let(:format) { :file }
+    let(:file_format) { :file }
     let(:content) { trie.to_a.join ' ' }
     let(:format_content) { ->(content) { content } }
   end

--- a/spec/lib/rambling/trie/serializers/marshal_spec.rb
+++ b/spec/lib/rambling/trie/serializers/marshal_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Marshal do
   it_behaves_like 'a serializer' do
-    let(:format) { :marshal }
+    let(:file_format) { :marshal }
     let(:format_content) { Marshal.method(:dump) }
   end
 end

--- a/spec/lib/rambling/trie/serializers/yaml_spec.rb
+++ b/spec/lib/rambling/trie/serializers/yaml_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Rambling::Trie::Serializers::Yaml do
   it_behaves_like 'a serializer' do
-    let(:format) { :yml }
+    let(:file_format) { :yml }
     let(:format_content) { YAML.method(:dump) }
   end
 end

--- a/spec/lib/rambling/trie/serializers/zip_spec.rb
+++ b/spec/lib/rambling/trie/serializers/zip_spec.rb
@@ -8,14 +8,14 @@ describe Rambling::Trie::Serializers::Zip do
     yml: YAML.method(:dump),
     marshal: Marshal.method(:dump),
     file: Marshal.method(:dump),
-  }.each do |format, dump_method|
-    context "with '.#{format}'" do
+  }.each do |file_format, dump_method|
+    context "with '.#{file_format}'" do
       it_behaves_like 'a serializer' do
         let(:properties) { Rambling::Trie::Configuration::Properties.new }
         let(:serializer) { described_class.new properties }
-        let(:format) { :zip }
+        let(:file_format) { :zip }
 
-        let(:filepath) { File.join tmp_path, "trie-root.#{format}.zip" }
+        let(:filepath) { File.join tmp_path, "trie-root.#{file_format}.zip" }
         let(:format_content) { ->(content) { zip dump_method.call content } }
         let(:filename) { File.basename(filepath).gsub %r{\.zip}, '' }
 

--- a/spec/lib/rambling/trie_spec.rb
+++ b/spec/lib/rambling/trie_spec.rb
@@ -28,14 +28,14 @@ describe Rambling::Trie do
 
     context 'with a filepath' do
       let(:filepath) { 'a test filepath' }
-      let(:reader) do
+      let :reader do
         instance_double 'Rambling::Trie::Readers::PlainText', :reader
       end
       let(:words) { %w(a couple of test words over here) }
 
       before do
         receive_and_yield = receive(:each_word)
-        words.inject(receive_and_yield) do |yielder, word|
+        words.inject receive_and_yield do |yielder, word|
           yielder.and_yield word
         end
 
@@ -54,7 +54,7 @@ describe Rambling::Trie do
 
     context 'without any reader' do
       let(:filepath) { 'a test filepath' }
-      let(:reader) do
+      let :reader do
         instance_double(
           'Rambling::Trie::Readers::PlainText',
           :reader,
@@ -82,7 +82,7 @@ describe Rambling::Trie do
     let(:root) { Rambling::Trie::Nodes::Raw.new }
     let(:compressor) { Rambling::Trie::Compressor.new }
     let(:container) { Rambling::Trie::Container.new root, compressor }
-    let(:serializer) do
+    let :serializer do
       instance_double(
         'Rambling::True::Serializers::File',
         :serializer,
@@ -101,21 +101,21 @@ describe Rambling::Trie do
     end
 
     context 'without a serializer' do
-      let(:marshal_serializer) do
+      let :marshal_serializer do
         instance_double(
           'Rambling::Trie::Serializers::Marshal',
           :marshal_serializer,
           load: nil,
         )
       end
-      let(:default_serializer) do
+      let :default_serializer do
         instance_double(
           'Rambling::Trie::Serializers::File',
           :default_serializer,
           load: nil,
         )
       end
-      let(:yaml_serializer) do
+      let :yaml_serializer do
         instance_double(
           'Rambling::Trie::Serializers::Yaml',
           :yaml_serializer,
@@ -168,26 +168,26 @@ describe Rambling::Trie do
   describe '.dump' do
     let(:filename) { 'a trie' }
     let(:root) { instance_double 'Rambling::Trie::Serializers::Marshal', :root }
-    let(:compressor) do
+    let :compressor do
       instance_double 'Rambling::Trie::Serializers::Marshal', :compressor
     end
     let(:trie) { Rambling::Trie::Container.new root, compressor }
 
-    let(:marshal_serializer) do
+    let :marshal_serializer do
       instance_double(
         'Rambling::Trie::Serializers::Marshal',
         :marshal_serializer,
         dump: nil,
       )
     end
-    let(:yaml_serializer) do
+    let :yaml_serializer do
       instance_double(
         'Rambling::Trie::Serializers::Yaml',
         :yaml_serializer,
         dump: nil,
       )
     end
-    let(:default_serializer) do
+    let :default_serializer do
       instance_double(
         'Rambling::Trie::Serializers::File',
         :default_serializer,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
   config.tty = true
   config.formatter = :documentation
   config.order = :random
-  config.run_all_when_everything_filtered = true
+  config.filter_run_when_matching :focus
   config.raise_errors_for_deprecations!
 end
 

--- a/spec/support/shared_examples/a_container_word.rb
+++ b/spec/support/shared_examples/a_container_word.rb
@@ -24,7 +24,7 @@ shared_examples_for 'a propagating node' do
     compressed_value, instance_double_class = test_params
 
     context "when root has compressed=#{compressed_value}" do
-      let(:root) do
+      let :root do
         instance_double(
           instance_double_class,
           :root,

--- a/spec/support/shared_examples/a_container_word.rb
+++ b/spec/support/shared_examples/a_container_word.rb
@@ -35,8 +35,8 @@ shared_examples_for 'a propagating node' do
       end
 
       it 'calls the root with the word characters' do
-        container.public_send method, 'words'
-        expect(root).to have_received(method).with %w(w o r d s)
+        container.public_send method_name, 'words'
+        expect(root).to have_received(method_name).with %w(w o r d s)
       end
     end
   end

--- a/spec/support/shared_examples/a_serializable_trie.rb
+++ b/spec/support/shared_examples/a_serializable_trie.rb
@@ -2,7 +2,7 @@
 
 shared_examples_for 'a serializable trie' do
   let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
-  let(:filepath) { File.join tmp_path, "trie-root.#{format}" }
+  let(:filepath) { File.join tmp_path, "trie-root.#{file_format}" }
 
   context 'with an uncompressed trie' do
     before { Rambling::Trie.dump trie_to_serialize, filepath }

--- a/spec/support/shared_examples/a_serializer.rb
+++ b/spec/support/shared_examples/a_serializer.rb
@@ -5,7 +5,7 @@ shared_examples_for 'a serializer' do
 
   let(:trie) { Rambling::Trie.create }
   let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
-  let(:filepath) { File.join tmp_path, "trie-root.#{format}" }
+  let(:filepath) { File.join tmp_path, "trie-root.#{file_format}" }
   let(:content) { trie.root }
 
   before do
@@ -52,7 +52,9 @@ shared_examples_for 'a serializer' do
 
         it "loads a compressed=#{compress_value} object" do
           loaded = serializer.load filepath
-          expect(loaded.compressed?).to be compress_value if :file != format
+          if :file != file_format
+            expect(loaded.compressed?).to be compress_value
+          end
         end
       end
     end

--- a/spec/support/shared_examples/a_trie_node.rb
+++ b/spec/support/shared_examples/a_trie_node.rb
@@ -71,7 +71,7 @@ shared_examples_for 'a trie node' do
   end
 
   describe 'delegates and aliases' do
-    let(:children_tree) do
+    let :children_tree do
       instance_double(
         'Hash',
         :children_tree,


### PR DESCRIPTION
... instead of deprecated `run_all_when_everything_filtered`. Also:

- Use non-reserved words for file format and method name so that we are not accidentally shadowing important built-ins (`:format` => `:file_format`, `:method` => `:method_name`)
- Explicitly assert any new `Node` is not a `#word?` by default after initialization
- Remove unnecessary parens from let definitions in specs