### PR TITLE
Update `CallTreeProfiler` to use new `RubyProf::Profiler` format

### DIFF
--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'benchmark/ips'
-
 namespace :ips do
   task :pop_shift_slice do
     compare_pop_shift_slice
@@ -33,6 +31,7 @@ namespace :ips do
 end
 
 def compare
+  require 'benchmark/ips'
   Benchmark.ips do |bm|
     yield bm
 

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -43,21 +43,14 @@ end
 def compare_pop_shift_slice
   compare do |bm|
     a = []
+    bm.report('push') { a.push 1 }
+    bm.report('pop') { a.pop }
 
-    bm.report 'push/pop' do
-      a.push 1
-      a.pop
-    end
+    bm.report('unshift') { a.unshift 1 }
+    bm.report('shift') { a.shift }
 
-    bm.report 'unshift/shift' do
-      a.unshift 1
-      a.shift
-    end
-
-    bm.report 'shovel(<<)/slice!(0)' do
-      a << 1
-      a.slice! 0
-    end
+    bm.report('shovel(<<)') { a << 1 }
+    bm.report('slice!(0)') { a.slice! 0 }
   end
 end
 

--- a/tasks/performance.rb
+++ b/tasks/performance.rb
@@ -10,8 +10,6 @@ arg_names = %i(type method)
 dependencies = %i(serialization:regenerate performance:directory)
 
 task :performance, arg_names => dependencies do |_, args|
-  require 'benchmark/ips'
-
   configuration = Performance::Configuration.new
   task = Performance::Task.new configuration
   task.run(**args)

--- a/tasks/performance/reporters/benchmark.rb
+++ b/tasks/performance/reporters/benchmark.rb
@@ -30,9 +30,7 @@ module Performance
 
         require 'benchmark'
         measure = ::Benchmark.measure do
-          iterations.times do
-            result = yield param
-          end
+          iterations.times { result = yield param }
         end
 
         output.puts result.to_s.ljust 10

--- a/tasks/performance/reporters/call_tree_profile.rb
+++ b/tasks/performance/reporters/call_tree_profile.rb
@@ -14,15 +14,11 @@ module Performance
         FileUtils.mkdir_p dirpath
 
         require 'ruby-prof'
-        result = RubyProf.profile merge_fibers: true do
-          params.each do |param|
-            iterations.times do
-              yield param
-            end
-          end
-        end
+        profile = RubyProf::Profile.new
+        profile.profile { params.each { |p| iterations.times { yield p } } }
+        profile.merge!
 
-        printer = RubyProf::CallTreePrinter.new result
+        printer = RubyProf::CallTreePrinter.new profile
         printer.print path: dirpath
       end
 

--- a/tasks/performance/reporters/flamegraph.rb
+++ b/tasks/performance/reporters/flamegraph.rb
@@ -15,11 +15,7 @@ module Performance
 
         require 'flamegraph'
         ::Flamegraph.generate filepath do
-          params.each do |param|
-            iterations.times do
-              yield param
-            end
-          end
+          params.each { |p| iterations.times { yield p } }
         end
       end
 

--- a/tasks/performance/reporters/memory_profile.rb
+++ b/tasks/performance/reporters/memory_profile.rb
@@ -19,11 +19,7 @@ module Performance
           ignore_files: 'lib/rambling/trie/tasks',
         ) do
           with_gc_stats "performing #{filename}" do
-            params.each do |param|
-              iterations.times do
-                yield param
-              end
-            end
+            params.each { |p| iterations.times { yield p } }
           end
         end
 


### PR DESCRIPTION
Plus:

- More accurate `pop`/`shift`/`slice!` reporting
- Only require `benchmark/ips` when necessary
- One-liner blocks