### PR TITLE
Exclude `spec/` from `simplecov` coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require 'yaml'
 require 'simplecov'
 
+COVERAGE_FILTER = %r{/spec/}.freeze
+
 if ENV.key? 'COVERALLS_REPO_TOKEN'
   require 'coveralls'
 
@@ -11,11 +13,9 @@ if ENV.key? 'COVERALLS_REPO_TOKEN'
     Coveralls::SimpleCov::Formatter,
   ]
 
-  Coveralls.wear! do
-    add_filter '/spec/'
-  end
+  Coveralls.wear! { add_filter COVERAGE_FILTER }
 else
-  SimpleCov.start
+  SimpleCov.start { add_filter COVERAGE_FILTER }
 end
 
 require 'rspec'


### PR DESCRIPTION
... by using the same filter as we use for `Coveralls.wear!`