### PR TITLE
Add rbs types and corresponding lint check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,10 @@
+version: "2"
 exclude_patterns:
   - 'tasks/'
+checks:
+  method-complexity:
+    config:
+      threshold: 7
 plugins:
   # No to-dos or similar
   fixme:
@@ -10,7 +15,7 @@ plugins:
   flog:
     enabled: true
     config:
-      score_threshold: 25.0
+      score_threshold: 28.5
     exclude_patterns:
       - 'spec/'
   # Markdown lint with rules from https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,8 +23,8 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
-      - name: Run rbs
-        run: bundle exec rbs validate lib/**/*.rb
+      - name: Run rbs + steep
+        run: bundle exec steep check
   spec:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.0
+          ruby-version: 3.3.6
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
@@ -65,7 +65,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.0
+          ruby-version: 3.3.6
           bundler-cache: true
       - name: Report rspec test coverage to coveralls.io
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,8 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
+      - name: Run rbs
+        run: bundle exec rbs validate lib/**/*.rb
   spec:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  lint-rubocop:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,6 +23,15 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
+  lint-rbs-steep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.6
+          bundler-cache: true
       - name: Run rbs + steep
         run: bundle exec steep check
   spec:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1327,6 +1327,8 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   Max: 20
+  AllowedMethods:
+    - 'closest_node'
   Exclude:
     - 'tasks/*.rb'
 
@@ -1353,6 +1355,9 @@ Metrics/ClassLength:
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
   Max: 6
+  AllowedMethods:
+    - 'children_match_prefix'
+    - 'closest_node'
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rbs'
-gem 'steep'
 gem 'rubyzip'
 
 group :development do
@@ -14,9 +12,11 @@ group :development do
   gem 'memory_profiler'
   gem 'pry'
   gem 'rake'
+  gem 'rbs'
   gem 'rspec'
   gem 'ruby-prof'
   gem 'stackprof'
+  gem 'steep'
   gem 'yard'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rbs'
 gem 'rubyzip'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rbs'
+gem 'steep'
 gem 'rubyzip'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem 'flamegraph'
   gem 'memory_profiler'
   gem 'pry'
+  gem 'racc'
   gem 'rake'
   gem 'rbs'
   gem 'rspec'

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,29 @@
+# D = Steep::Diagnostic
+#
+target :lib do
+  signature 'sig'
+
+  check 'lib'                       # Directory name
+#   check 'Gemfile'                   # File name
+#   check 'app/models/**/*.rb'        # Glob
+#   # ignore 'lib/templates/*.rb'
+#
+#   # library 'pathname'              # Standard libraries
+#   # library 'strong_json'           # Gems
+#
+#   # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
+#   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
+#   # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
+#   # configure_code_diagnostics(D::Ruby.silent)       # `silent` diagnostics setting
+#   # configure_code_diagnostics do |hash|             # You can setup everything yourself
+#   #   hash[D::Ruby::NoMethod] = :information
+#   # end
+end
+
+# target :test do
+#   signature 'sig', 'sig-private'
+#
+#   check 'test'
+#
+#   # library 'pathname'              # Standard libraries
+# end

--- a/Steepfile
+++ b/Steepfile
@@ -3,13 +3,17 @@
 target :lib do
   signature 'sig'
 
-  check 'lib'                       # Directory name
-#   check 'Gemfile'                   # File name
-#   check 'app/models/**/*.rb'        # Glob
-#   # ignore 'lib/templates/*.rb'
-#
-#   # library 'pathname'              # Standard libraries
-#   # library 'strong_json'           # Gems
+  check 'lib'
+  # check 'tasks'
+
+  # check 'Gemfile'
+  # check 'Guardfile'
+  # check 'Rakefile'
+  # check 'Steepfile'
+
+  # library 'rubyzip'
+  library 'yaml'
+  library 'securerandom'
 #
 #   # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
 #   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting

--- a/Steepfile
+++ b/Steepfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # D = Steep::Diagnostic
 #
 target :lib do
@@ -14,14 +16,14 @@ target :lib do
   # library 'rubyzip'
   library 'yaml'
   library 'securerandom'
-#
-#   # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
-#   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
-#   # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
-#   # configure_code_diagnostics(D::Ruby.silent)       # `silent` diagnostics setting
-#   # configure_code_diagnostics do |hash|             # You can setup everything yourself
-#   #   hash[D::Ruby::NoMethod] = :information
-#   # end
+
+  # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
+  # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
+  # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
+  # configure_code_diagnostics(D::Ruby.silent)       # `silent` diagnostics setting
+  # configure_code_diagnostics do |hash|             # You can setup everything yourself
+  #   hash[D::Ruby::NoMethod] = :information
+  # end
 end
 
 # target :test do

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -26,7 +26,7 @@ module Rambling
           if filepath
             reader ||= readers.resolve filepath
             # noinspection RubyMismatchedArgumentType,RubyNilAnalysis
-            reader.each_word filepath do |word|
+            (reader || raise).each_word filepath do |word|
               container << word
             end
           end
@@ -48,7 +48,7 @@ module Rambling
       #   discouraged. Only use the +.marshal+ format with trusted input.
       def load filepath, serializer = nil
         serializer ||= serializers.resolve filepath
-        root = serializer.load filepath
+        root = (serializer || raise).load filepath
         Rambling::Trie::Container.new root, compressor do |container|
           yield container if block_given?
         end
@@ -66,7 +66,7 @@ module Rambling
       def dump trie, filepath, serializer = nil
         serializer ||= serializers.resolve filepath
         # noinspection RubyNilAnalysis
-        serializer.dump trie.root, filepath
+        (serializer || raise).dump trie.root, filepath
       end
 
       # Provides configuration properties for the +Rambling::Trie+ gem.

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -8,6 +8,8 @@ module Rambling
       # @param [Nodes::Node] node the node to compress.
       # @return [Nodes::Compressed] node the compressed version of the node.
       def compress node
+        return if node.nil?
+
         if node.compressible?
           compress_child_and_merge node
         else

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -5,7 +5,7 @@ module Rambling
     # Responsible for the compression process of a trie data structure.
     class Compressor
       # Compresses a {Nodes::Node Node} from a trie data structure.
-      # @param [Nodes::Raw] node the node to compress.
+      # @param [Nodes::Node] node the node to compress.
       # @return [Nodes::Compressed] node the compressed version of the node.
       def compress node
         if node.compressible?

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -104,7 +104,9 @@ module Rambling
         end
 
         def contains? provider
-          provider.nil? || (providers.any? && provider_instances.include?(provider))
+          return true if provider.nil?
+          p = (provider || raise)
+          providers.any? && provider_instances.include?(p)
         end
 
         alias_method :provider_instances, :values

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -58,7 +58,12 @@ module Rambling
         # @param [String] filepath the filepath to resolve into a provider.
         # @return [TProvider, nil] the provider for the given file's extension. {#default} if not found.
         def resolve filepath
-          providers[file_format filepath] || default
+          extension = file_format filepath
+          if providers.key? extension
+            providers[extension]
+          else
+            default
+          end
         end
 
         # Resets the provider collection to the initial values.

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -105,6 +105,7 @@ module Rambling
 
         def contains? provider
           return true if provider.nil?
+
           p = (provider || raise)
           providers.any? && provider_instances.include?(p)
         end

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -111,7 +111,7 @@ module Rambling
         def contains? provider
           return true if provider.nil?
 
-          p = (provider || raise)
+          p = provider || raise
           providers.any? && provider_instances.include?(p)
         end
 

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -201,16 +201,18 @@ module Rambling
         return enum_for :words_within_root, phrase unless block_given?
 
         chars = phrase.chars
+        # rubocop:disable Style/CommentedKeyword
         0.upto(chars.length - 1).each do |starting_index|
-          new_phrase = chars.slice starting_index..(chars.length - 1) #: Array[String]
+          new_phrase = chars.slice starting_index..(chars.length - 1) # : Array[String]
           root.match_prefix new_phrase do |word|
             yield word
           end
-        end #: Enumerator[String, void]
+        end # : Enumerator[String, void]
+        # rubocop:enable Style/CommentedKeyword
       end
 
       def compress_root
-         compressor.compress root #: Nodes::Compressed
+        compressor.compress root # : Nodes::Compressed
       end
 
       def char_symbols word

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -207,6 +207,8 @@ module Rambling
             yield word
           end
         end
+
+        nil
       end
 
       def compress_root

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -98,7 +98,7 @@ module Rambling
 
       # Returns all words within a string that match a word contained in the trie.
       # @param [String] phrase the string to look for matching words in.
-      # @return [Enumerator<String>] all the words in the given string that match a word in the trie.
+      # @return [Array<String>] all the words in the given string that match a word in the trie.
       # @yield [String] each word found in phrase.
       def words_within phrase
         words_within_root(phrase).to_a

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -202,17 +202,15 @@ module Rambling
 
         chars = phrase.chars
         0.upto(chars.length - 1).each do |starting_index|
-          new_phrase = chars.slice starting_index..(chars.length - 1)
+          new_phrase = chars.slice starting_index..(chars.length - 1) #: Array[String]
           root.match_prefix new_phrase do |word|
             yield word
           end
-        end
-
-        nil
+        end #: Enumerator[String, void]
       end
 
       def compress_root
-        compressor.compress root
+         compressor.compress root #: Nodes::Compressed
       end
 
       def char_symbols word

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -28,7 +28,7 @@ module Rambling
       # @see Nodes::Raw#add
       # @see Nodes::Compressed#add
       def add word
-        root.add char_symbols word
+        root.add reversed_char_symbols word
       end
 
       # Adds all provided words to the trie.
@@ -215,7 +215,7 @@ module Rambling
         compressor.compress root # : Nodes::Compressed
       end
 
-      def char_symbols word
+      def reversed_char_symbols word
         symbols = []
         word.reverse.each_char { |c| symbols << c.to_sym }
         symbols

--- a/lib/rambling/trie/enumerable.rb
+++ b/lib/rambling/trie/enumerable.rb
@@ -6,6 +6,8 @@ module Rambling
     module Enumerable
       include ::Enumerable
 
+      EMPTY_ENUMERATOR = [].to_enum :each
+
       # Returns number of words contained in the trie
       # @see https://ruby-doc.org/3.3.0/Enumerable.html#method-i-count Enumerable#count
       alias_method :size, :count

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -77,15 +77,15 @@ module Rambling
         def children_match_prefix chars
           return enum_for :children_match_prefix, chars unless block_given?
 
-          return if chars.empty?
+          return EMPTY_ENUMERATOR if chars.empty?
 
           child = children_tree[chars.first.to_sym]
-          return unless child
+          return EMPTY_ENUMERATOR unless child
 
           child_letter = child.letter.to_s
           letter = chars.slice!(0, child_letter.size).join
 
-          return unless child_letter == letter
+          return EMPTY_ENUMERATOR unless child_letter == letter
 
           child.match_prefix chars do |word|
             yield word

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -23,13 +23,13 @@ module Rambling
         private
 
         def partial_word_chars? chars
-          child = children_tree[chars.first.to_sym]
+          child = children_tree[(chars.first || raise).to_sym]
           return false unless child
 
           child_letter = child.letter.to_s
 
           if chars.size >= child_letter.size
-            letter = chars.slice!(0, child_letter.size).join
+            letter = (chars.slice!(0, child_letter.size) || raise).join
             return child.partial_word? chars if child_letter == letter
           end
 
@@ -39,7 +39,7 @@ module Rambling
         end
 
         def word_chars? chars
-          letter = chars.slice! 0
+          letter = chars.slice!(0) || raise
           letter_sym = letter.to_sym
 
           child = children_tree[letter_sym]
@@ -50,7 +50,7 @@ module Rambling
 
             break if chars.empty?
 
-            letter << chars.slice!(0)
+            letter << (chars.slice!(0) || raise)
             letter_sym = letter.to_sym
           end
 
@@ -58,13 +58,13 @@ module Rambling
         end
 
         def closest_node chars
-          child = children_tree[chars.first.to_sym]
+          child = children_tree[(chars.first || raise).to_sym]
           return missing unless child
 
           child_letter = child.letter.to_s
 
           if chars.size >= child_letter.size
-            letter = chars.slice!(0, child_letter.size).join
+            letter = (chars.slice!(0, child_letter.size) || raise).join
             return child.scan chars if child_letter == letter
           end
 
@@ -79,11 +79,11 @@ module Rambling
 
           return EMPTY_ENUMERATOR if chars.empty?
 
-          child = children_tree[chars.first.to_sym]
+          child = children_tree[(chars.first || raise).to_sym]
           return EMPTY_ENUMERATOR unless child
 
           child_letter = child.letter.to_s
-          letter = chars.slice!(0, child_letter.size).join
+          letter = (chars.slice!(0, child_letter.size) || raise).join
 
           return EMPTY_ENUMERATOR unless child_letter == letter
 

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -52,6 +52,8 @@ module Rambling
           # rubocop:disable Lint/UnreachableLoop
           children_tree.each_value { |child| return child }
           # rubocop:enable Lint/UnreachableLoop
+
+          nil
         end
 
         # Indicates if the current node is the root node.

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -147,7 +147,7 @@ module Rambling
         # Delete a given letter and its corresponding {Node Node} from
         # this {Node Node}'s children tree.
         # @param [Symbol] letter the letter to delete from the node's children tree.
-        # @return [Node] the node corresponding to the deleted letter.
+        # @return [Node, nil] the node corresponding to the deleted letter.
         # @see https://ruby-doc.org/3.3.0/Hash.html#method-i-delete Hash#delete
         def delete letter
           children_tree.delete letter

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -167,6 +167,24 @@ module Rambling
         private
 
         attr_accessor :terminal
+
+        # abstract methods
+
+        def children_match_prefix chars
+          raise NotImplementedError
+        end
+
+        def partial_word_chars? chars
+          raise NotImplementedError
+        end
+
+        def word_chars? chars
+          raise NotImplementedError
+        end
+
+        def closest_node chars
+          raise NotImplementedError
+        end
       end
     end
   end

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -108,7 +108,7 @@ module Rambling
         end
 
         # Returns all words that match a prefix of any length within chars.
-        # @param [String] chars the chars to base the prefix on.
+        # @param [Array[String]] chars the chars to base the prefix on.
         # @return [Enumerator<String>] all the words that match a prefix by chars.
         # @yield [String] each word found.
         def match_prefix chars

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -32,6 +32,7 @@ module Rambling
         # Creates a new node.
         # @param [Symbol, nil] letter the Node's letter value.
         # @param [Node, nil] parent the parent of the current node.
+        # @param [Hash<Symbol, Node>] children_tree the children tree of the current node.
         def initialize letter = nil, parent = nil, children_tree = {}
           @letter = letter
           @parent = parent

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -6,15 +6,15 @@ module Rambling
       # A representation of a node in an uncompressed trie data structure.
       class Raw < Rambling::Trie::Nodes::Node
         # Adds a word to the current raw (uncompressed) trie node.
-        # @param [Array<Symbol>] chars the char array to add to the trie.
+        # @param [Array<Symbol>] reversed_chars the char array to add to the trie, in reverse order.
         # @return [Node] the added/modified node based on the word added.
         # @note This method clears the contents of the chars variable.
-        def add chars
-          if chars.empty?
+        def add reversed_chars
+          if reversed_chars.empty?
             terminal! unless root?
             self
           else
-            add_to_children_tree chars
+            add_to_children_tree reversed_chars
           end
         end
 

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -66,12 +66,12 @@ module Rambling
         def children_match_prefix chars
           return enum_for :children_match_prefix, chars unless block_given?
 
-          return if chars.empty?
+          return EMPTY_ENUMERATOR if chars.empty?
 
           letter = chars.shift.to_sym
           child = children_tree[letter]
 
-          return unless child
+          return EMPTY_ENUMERATOR unless child
 
           child.match_prefix chars do |word|
             yield word

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -27,7 +27,7 @@ module Rambling
         private
 
         def add_to_children_tree chars
-          letter = chars.pop
+          letter = chars.pop || raise
           child = children_tree[letter] || new_node(letter)
           child.add chars
           child
@@ -40,7 +40,7 @@ module Rambling
         end
 
         def partial_word_chars? chars = []
-          letter = chars.shift.to_sym
+          letter = (chars.shift || raise).to_sym
           child = children_tree[letter]
           return false unless child
 
@@ -48,7 +48,7 @@ module Rambling
         end
 
         def word_chars? chars = []
-          letter = chars.shift.to_sym
+          letter = (chars.shift || raise).to_sym
           child = children_tree[letter]
           return false unless child
 
@@ -56,7 +56,7 @@ module Rambling
         end
 
         def closest_node chars
-          letter = chars.shift.to_sym
+          letter = (chars.shift || raise).to_sym
           child = children_tree[letter]
           return missing unless child
 
@@ -68,7 +68,7 @@ module Rambling
 
           return EMPTY_ENUMERATOR if chars.empty?
 
-          letter = chars.shift.to_sym
+          letter = (chars.shift || raise).to_sym
           child = children_tree[letter]
 
           return EMPTY_ENUMERATOR unless child

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -7,7 +7,7 @@ module Rambling
       class Raw < Rambling::Trie::Nodes::Node
         # Adds a word to the current raw (uncompressed) trie node.
         # @param [Array<Symbol>] chars the char array to add to the trie.
-        # @return [Raw] the added/modified node based on the word added.
+        # @return [Node] the added/modified node based on the word added.
         # @note This method clears the contents of the chars variable.
         def add chars
           if chars.empty?

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -26,12 +26,14 @@ module Rambling
 
           ::Zip::File.open filepath do |zip|
             entry = zip.entries.first
-            return nil if entry.nil?
+            raise if entry.nil?
 
             entry_path = path entry.name
             entry.extract entry_path
 
             serializer = serializers.resolve entry.name
+            raise if serializer.nil?
+
             serializer.load entry_path
           end
         end
@@ -50,6 +52,8 @@ module Rambling
 
             entry_path = path filename
             serializer = serializers.resolve filename
+
+            raise if serializer.nil?
             serializer.dump contents, entry_path
 
             zip.add filename, entry_path

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -54,6 +54,7 @@ module Rambling
             serializer = serializers.resolve filename
 
             raise if serializer.nil?
+
             serializer.dump contents, entry_path
 
             zip.add filename, entry_path

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -4,11 +4,11 @@ module Rambling
 
     @properties: Configuration::Properties
 
-    def self.create: (String?, Readers::Reader?) ?{ (Container) -> void } -> Container
+    def self.create: (?String?, ?Readers::Reader?) ?{ (Container) -> void } -> Container
 
-    def self.load: (String, Serializers::Serializer[Nodes::Node]?) ?{ (Container) -> void } -> Container
+    def self.load: (String, ?Serializers::Serializer[Nodes::Node]?) ?{ (Container) -> void } -> Container
 
-    def self.dump: (Container, String, Serializers::Serializer[Nodes::Node]?) -> void
+    def self.dump: (Container, String, ?Serializers::Serializer[Nodes::Node]?) -> void
 
     def self.config: ?{ (Configuration::Properties) -> void } -> Configuration::Properties
 

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -4,24 +4,24 @@ module Rambling
 
     @properties: Configuration::Properties
 
-    def create: (String?, Readers::Reader?) { (Container) -> void } -> Container
+    def self.create: (String?, Readers::Reader?) { (Container) -> void } -> Container
 
-    def load: (String, Serializers::Serializer[untyped]?) -> Container
+    def self.load: (String, Serializers::Serializer[Nodes::Node]?) -> Container
 
-    def dump: (Container, String, Serializers::Serializer[untyped]?) -> void
+    def self.dump: (Container, String, Serializers::Serializer[Nodes::Node]?) -> void
 
-    def config: { (Configuration::Properties) -> void } -> Configuration::Properties
+    def self.config: { (Configuration::Properties) -> void } -> Configuration::Properties
 
     private
 
-    def properties: -> untyped
+    def self.properties: -> Configuration::Properties
 
-    def readers: -> untyped
+    def self.readers: -> Configuration::ProviderCollection[Readers::Reader]
 
-    def serializers: -> untyped
+    def self.serializers: -> Configuration::ProviderCollection[Serializers::Serializer[Nodes::Node]]
 
-    def compressor: -> untyped
+    def self.compressor: -> Compressor
 
-    def root_builder: -> ^() -> Nodes::Node
+    def self.root_builder: -> ^() -> Nodes::Node
   end
 end

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -1,0 +1,27 @@
+module Rambling
+  module Trie
+    VERSION: String
+
+    @properties: Configuration::Properties
+
+    def create: (String?, Readers::Reader?) { (Container) -> void } -> Container
+
+    def load: (String, Serializers::Serializer[untyped]?) -> Container
+
+    def dump: (Container, String, Serializers::Serializer[untyped]?) -> void
+
+    def config: { (Configuration::Properties) -> void } -> Configuration::Properties
+
+    private
+
+    def properties: -> untyped
+
+    def readers: -> untyped
+
+    def serializers: -> untyped
+
+    def compressor: -> untyped
+
+    def root_builder: -> ^() -> Nodes::Node
+  end
+end

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -4,13 +4,13 @@ module Rambling
 
     @properties: Configuration::Properties
 
-    def self.create: (String?, Readers::Reader?) { (Container) -> void } -> Container
+    def self.create: (String?, Readers::Reader?) ?{ (Container) -> void } -> Container
 
-    def self.load: (String, Serializers::Serializer[Nodes::Node]?) -> Container
+    def self.load: (String, Serializers::Serializer[Nodes::Node]?) ?{ (Container) -> void } -> Container
 
     def self.dump: (Container, String, Serializers::Serializer[Nodes::Node]?) -> void
 
-    def self.config: { (Configuration::Properties) -> void } -> Configuration::Properties
+    def self.config: ?{ (Configuration::Properties) -> void } -> Configuration::Properties
 
     private
 

--- a/sig/lib/rambling/trie/comparable.rbs
+++ b/sig/lib/rambling/trie/comparable.rbs
@@ -2,6 +2,16 @@ module Rambling
   module Trie
     module Comparable
       def ==: (Nodes::Node) -> bool
+
+      private
+
+      # abstract methods
+
+      def letter: -> Symbol
+
+      def terminal?: -> bool
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
     end
   end
 end

--- a/sig/lib/rambling/trie/comparable.rbs
+++ b/sig/lib/rambling/trie/comparable.rbs
@@ -1,0 +1,7 @@
+module Rambling
+  module Trie
+    module Comparable
+      def ==: (Nodes::Node) -> bool
+    end
+  end
+end

--- a/sig/lib/rambling/trie/compressible.rbs
+++ b/sig/lib/rambling/trie/compressible.rbs
@@ -2,6 +2,16 @@ module Rambling
   module Trie
     module Compressible
       def compressible?: -> bool
+
+      private
+
+      # abstract methods
+
+      def root?: -> bool
+
+      def terminal?: -> bool
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
     end
   end
 end

--- a/sig/lib/rambling/trie/compressible.rbs
+++ b/sig/lib/rambling/trie/compressible.rbs
@@ -1,0 +1,7 @@
+module Rambling
+  module Trie
+    module Compressible
+      def compressible?: -> bool
+    end
+  end
+end

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -1,13 +1,13 @@
 module Rambling
   module Trie
     class Compressor
-      def compress: (Nodes::Node) -> Nodes::Compressed
+      def compress: (Nodes::Node?) -> Nodes::Compressed?
 
       private
 
       def compress_child_and_merge: (Nodes::Node) -> Nodes::Compressed
 
-      def merge: (Nodes::Node, Nodes::Node) -> Nodes::Compressed
+      def merge: (Nodes::Node, Nodes::Node?) -> Nodes::Compressed
 
       def compress_children_and_copy: (Nodes::Node) -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -1,0 +1,19 @@
+module Rambling
+  module Trie
+    class Compressor
+      def compress: (Nodes::Node) -> Nodes::Compressed
+
+      private
+
+      def compress_child_and_merge: (Nodes::Node) -> Nodes::Compressed
+
+      def merge: (Nodes::Node, Nodes::Node) -> Nodes::Compressed
+
+      def compress_children_and_copy: (Nodes::Node) -> Nodes::Compressed
+
+      def compress_children: (Hash[Symbol, Nodes::Node]) -> Hash[Symbol, Nodes::Node]
+
+      def new_compressed_node: (Symbol?, Nodes::Node?, Hash[Symbol, Nodes::Node], bool?) -> untyped
+    end
+  end
+end

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -13,7 +13,7 @@ module Rambling
 
       def compress_children: (Hash[Symbol, Nodes::Node]) -> Hash[Symbol, Nodes::Node]
 
-      def new_compressed_node: (Symbol?, Nodes::Node?, Hash[Symbol, Nodes::Node], bool?) -> untyped
+      def new_compressed_node: (Symbol?, Nodes::Node?, Hash[Symbol, Nodes::Node], bool?) -> Nodes::Compressed
     end
   end
 end

--- a/sig/lib/rambling/trie/configuration/properties.rbs
+++ b/sig/lib/rambling/trie/configuration/properties.rbs
@@ -1,0 +1,24 @@
+module Rambling
+  module Trie
+    module Configuration
+      class Properties
+        attr_reader readers: ProviderCollection[Readers::Reader]
+        attr_reader serializers: ProviderCollection[Serializers::Serializer[untyped]]
+        attr_accessor compressor: Compressor
+        attr_accessor root_builder: ^() -> Nodes::Node
+        attr_accessor tmp_path: String
+
+        def reset: -> void
+
+        private
+
+        attr_writer readers: ProviderCollection[Readers::Reader]
+        attr_writer serializers: ProviderCollection[Serializers::Serializer[untyped]]
+
+        def reset_readers: -> void
+
+        def reset_serializers: -> void
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/configuration/properties.rbs
+++ b/sig/lib/rambling/trie/configuration/properties.rbs
@@ -3,19 +3,23 @@ module Rambling
     module Configuration
       class Properties
         attr_reader readers: ProviderCollection[Readers::Reader]
-        attr_reader serializers: ProviderCollection[Serializers::Serializer[untyped]]
+        attr_reader serializers: ProviderCollection[Serializers::Serializer[Nodes::Node]]
         attr_accessor compressor: Compressor
         attr_accessor root_builder: ^() -> Nodes::Node
         attr_accessor tmp_path: String
+
+        def initialize: -> void
 
         def reset: -> void
 
         private
 
         attr_writer readers: ProviderCollection[Readers::Reader]
-        attr_writer serializers: ProviderCollection[Serializers::Serializer[untyped]]
+        attr_writer serializers: ProviderCollection[Serializers::Serializer[Nodes::Node]]
 
         def reset_readers: -> void
+
+        def default_reader_providers: -> Hash[Symbol, Readers::Reader]
 
         def reset_serializers: -> void
       end

--- a/sig/lib/rambling/trie/configuration/provider_collection.rbs
+++ b/sig/lib/rambling/trie/configuration/provider_collection.rbs
@@ -1,7 +1,11 @@
 module Rambling
   module Trie
     module Configuration
-      class ProviderCollection[TProvider]
+      class ProviderCollection[TProvider < _Nilable]
+        interface _Nilable
+          def nil?: -> bool
+        end
+
         @providers: Hash[Symbol, TProvider]
 
         attr_reader name: Symbol

--- a/sig/lib/rambling/trie/configuration/provider_collection.rbs
+++ b/sig/lib/rambling/trie/configuration/provider_collection.rbs
@@ -7,6 +7,8 @@ module Rambling
         attr_reader name: Symbol
         attr_reader default: TProvider?
 
+        def initialize: (Symbol, Hash[Symbol, TProvider], ?TProvider?) -> void
+
         def []: (Symbol) -> TProvider
 
         def add: (Symbol, TProvider) -> TProvider
@@ -32,7 +34,7 @@ module Rambling
 
         def file_format: (String) -> Symbol
 
-        def contains?: (TProvider) -> bool
+        def contains?: (TProvider?) -> bool
 
         alias provider_instances values
       end

--- a/sig/lib/rambling/trie/configuration/provider_collection.rbs
+++ b/sig/lib/rambling/trie/configuration/provider_collection.rbs
@@ -1,0 +1,41 @@
+module Rambling
+  module Trie
+    module Configuration
+      class ProviderCollection[TProvider]
+        @providers: Hash[Symbol, TProvider]
+
+        attr_reader name: Symbol
+        attr_reader default: TProvider?
+
+        def []: (Symbol) -> TProvider
+
+        def add: (Symbol, TProvider) -> TProvider
+
+        def default=: (TProvider) -> TProvider
+
+        def formats: -> Array[Symbol]
+
+        def providers: -> Hash[Symbol, TProvider]
+
+        def reset: -> void
+
+        def resolve: (String) -> TProvider?
+
+        private
+
+        attr_reader configured_default: TProvider?
+        attr_reader configured_providers: Hash[Symbol, TProvider]
+
+        def []=: (Symbol, TProvider) -> TProvider
+
+        def values: -> Array[TProvider]
+
+        def file_format: (String) -> Symbol
+
+        def contains?: (TProvider) -> bool
+
+        alias provider_instances values
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/configuration/provider_collection.rbs
+++ b/sig/lib/rambling/trie/configuration/provider_collection.rbs
@@ -13,7 +13,7 @@ module Rambling
 
         def add: (Symbol, TProvider) -> TProvider
 
-        def default=: (TProvider) -> TProvider
+        def default=: (TProvider?) -> TProvider?
 
         def formats: -> Array[Symbol]
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -55,7 +55,7 @@ module Rambling
       attr_reader compressor: Compressor
       attr_writer root: Nodes::Node
 
-      def words_within_root: (String) { (String) -> void } -> (Enumerator[String, void] | Numeric)
+      def words_within_root: (String) { (String) -> void } -> (Enumerator[String, void]?)
 
       def compress_root: -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -55,7 +55,7 @@ module Rambling
       attr_reader compressor: Compressor
       attr_writer root: Nodes::Node
 
-      def words_within_root: (String) { (String) -> void } -> (Enumerator[String, void]?)
+      def words_within_root: (String) ?{ (String) -> void } -> (Enumerator[String, void]?)
 
       def compress_root: -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -1,0 +1,63 @@
+module Rambling
+  module Trie
+    class Container
+      @compressor: Compressor
+
+      attr_reader root: Nodes::Node
+
+      def add: (String) -> Nodes::Node
+
+      def concat: (Array[String]) -> Array[Nodes::Node]
+
+      def compress!: -> Container
+
+      def compress: -> Container
+
+      def each: -> (Enumerator[String, void] | Nodes::Node)
+
+      def partial_word?: (String) -> bool
+
+      def word?: (String) -> bool
+
+      def scan: (String) -> Array[String]
+
+      def words_within: (String) -> Array[String]
+
+      def words_within?: (String) -> bool
+
+      def ==: (Container) -> bool
+
+      def []: (Symbol) -> Nodes::Node
+
+      def children: -> Array[Nodes::Node]
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
+
+      def compressed?: -> bool
+
+      def to_a: -> Array[String]
+
+      def key?: (Symbol) -> bool
+
+      def size: -> Numeric
+
+      alias include? word?
+      alias match? partial_word?
+      alias words? scan
+      alias << add
+      alias has_key? key?
+      alias has_letter? key?
+
+      private
+
+      attr_reader compressor: Compressor
+      attr_writer root: Nodes::Node
+
+      def words_within_root: (String) -> (Enumerator[String, void] | Numeric)
+
+      def compress_root: -> Nodes::Compressed
+
+      def char_symbols: (String) -> Array[Symbol]
+    end
+  end
+end

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -21,6 +21,8 @@ module Rambling
 
       def partial_word?: (String) -> bool
 
+      def push: (*String) -> Array[Nodes::Node]
+
       def word?: (String) -> bool
 
       def scan: (String) -> Array[String]

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -59,7 +59,7 @@ module Rambling
       attr_reader compressor: Compressor
       attr_writer root: Nodes::Node
 
-      def words_within_root: (String) ?{ (String) -> void } -> (Enumerator[String, void]?)
+      def words_within_root: (String) ?{ (String) -> void } -> Enumerator[String, void]
 
       def compress_root: -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -1,11 +1,13 @@
 module Rambling
   module Trie
     class Container
+      include ::Enumerable[String]
+
       @compressor: Compressor
 
       attr_reader root: Nodes::Node
 
-      def initialize: (Nodes::Node, Compressor) { (Container) -> void } -> void
+      def initialize: (Nodes::Node, Compressor) ?{ (Container) -> void } -> void
 
       def add: (String) -> Nodes::Node
 
@@ -15,7 +17,7 @@ module Rambling
 
       def compress: -> Container
 
-      def each: -> (Enumerator[String, void] | Enumerable)
+      def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable)
 
       def partial_word?: (String) -> bool
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -63,7 +63,7 @@ module Rambling
 
       def compress_root: -> Nodes::Compressed
 
-      def char_symbols: (String) -> Array[Symbol]
+      def reversed_char_symbols: (String) -> Array[Symbol]
     end
   end
 end

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -5,6 +5,8 @@ module Rambling
 
       attr_reader root: Nodes::Node
 
+      def initialize: (Nodes::Node, Compressor) { (Container) -> void } -> void
+
       def add: (String) -> Nodes::Node
 
       def concat: (Array[String]) -> Array[Nodes::Node]
@@ -13,7 +15,7 @@ module Rambling
 
       def compress: -> Container
 
-      def each: -> (Enumerator[String, void] | Nodes::Node)
+      def each: -> (Enumerator[String, void] | Enumerable)
 
       def partial_word?: (String) -> bool
 
@@ -53,7 +55,7 @@ module Rambling
       attr_reader compressor: Compressor
       attr_writer root: Nodes::Node
 
-      def words_within_root: (String) -> (Enumerator[String, void] | Numeric)
+      def words_within_root: (String) { (String) -> void } -> (Enumerator[String, void] | Numeric)
 
       def compress_root: -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Enumerable
-      include ::Enumerable[Nodes::Node]
+      include ::Enumerable[String]
 
       alias size count
 

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -3,6 +3,8 @@ module Rambling
     module Enumerable
       include ::Enumerable[String]
 
+      EMPTY_ENUMERATOR: Enumerator[String, void]
+
       alias size count
 
       def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable)

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -6,6 +6,16 @@ module Rambling
       alias size count
 
       def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable)
+
+      private
+
+      # abstract methods
+
+      def as_word: -> String
+
+      def terminal?: -> bool
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
     end
   end
 end

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -1,0 +1,11 @@
+module Rambling
+  module Trie
+    module Enumerable
+      include ::Enumerable[Nodes::Node]
+
+      alias size count
+
+      def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable)
+    end
+  end
+end

--- a/sig/lib/rambling/trie/inspectable.rbs
+++ b/sig/lib/rambling/trie/inspectable.rbs
@@ -1,0 +1,19 @@
+module Rambling
+  module Trie
+    module Inspectable
+      def inspect: -> String
+
+      private
+
+      def class_name: -> String?
+
+      def attributes: -> String
+
+      def letter_inspect: -> String
+
+      def terminal_inspect: -> String
+
+      def children_inspect: -> String
+    end
+  end
+end

--- a/sig/lib/rambling/trie/inspectable.rbs
+++ b/sig/lib/rambling/trie/inspectable.rbs
@@ -14,6 +14,14 @@ module Rambling
       def terminal_inspect: -> String
 
       def children_inspect: -> String
+
+      # abstract methods
+
+      def letter: -> Symbol
+
+      def terminal: -> bool?
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
     end
   end
 end

--- a/sig/lib/rambling/trie/invalid_operation.rbs
+++ b/sig/lib/rambling/trie/invalid_operation.rbs
@@ -1,0 +1,7 @@
+module Rambling
+  module Trie
+    class InvalidOperation < RuntimeError
+      def initialize: (String? message) -> void
+    end
+  end
+end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -14,7 +14,7 @@ module Rambling
 
         def closest_node: (Array[String]) -> Node
 
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -8,13 +8,15 @@ module Rambling
 
         private
 
+        # overrides
+
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
+
         def partial_word_chars?: (Array[String]) -> bool
 
         def word_chars?: (Array[String]) -> bool
 
         def closest_node: (Array[String]) -> Node
-
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -14,7 +14,7 @@ module Rambling
 
         def closest_node: (Array[String | Symbol]) -> Node
 
-        def children_match_prefix: (Array[String | Symbol]) -> Enumerator[String, void]
+        def children_match_prefix: (Array[String | Symbol]) { (String) -> void } -> Enumerator[String, void]?
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -1,0 +1,21 @@
+module Rambling
+  module Trie
+    module Nodes
+      class Compressed < Node
+        def add: (Array[Symbol]) -> Node
+
+        def compressed?: -> bool
+
+        private
+
+        def partial_word_chars?: (Array[String | Symbol]) -> bool
+
+        def word_chars?: (Array[String | Symbol]) -> bool
+
+        def closest_node: (Array[String | Symbol]) -> Node
+
+        def children_match_prefix: (Array[String | Symbol]) -> Enumerator[String, void]
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -8,13 +8,13 @@ module Rambling
 
         private
 
-        def partial_word_chars?: (Array[String | Symbol]) -> bool
+        def partial_word_chars?: (Array[String]) -> bool
 
-        def word_chars?: (Array[String | Symbol]) -> bool
+        def word_chars?: (Array[String]) -> bool
 
-        def closest_node: (Array[String | Symbol]) -> Node
+        def closest_node: (Array[String]) -> Node
 
-        def children_match_prefix: (Array[String | Symbol]) { (String) -> void } -> Enumerator[String, void]?
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/missing.rbs
+++ b/sig/lib/rambling/trie/nodes/missing.rbs
@@ -1,0 +1,8 @@
+module Rambling
+  module Trie
+    module Nodes
+      class Missing < Node
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/nodes/missing.rbs
+++ b/sig/lib/rambling/trie/nodes/missing.rbs
@@ -2,6 +2,7 @@ module Rambling
   module Trie
     module Nodes
       class Missing < Node
+        def initialize: -> void
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -1,0 +1,47 @@
+module Rambling
+  module Trie
+    module Nodes
+      class Node
+        attr_reader letter: Symbol?
+        attr_accessor children_tree: Hash[Symbol, Node]
+        attr_accessor parent: Node?
+
+        def children: -> Array[Node]
+
+        def first_child: -> Node?
+
+        def match_prefix: (String) { (String) -> void } -> Enumerator[String, void]
+
+        def root?: -> bool
+
+        def scan: (Array[String]) -> Node
+
+        def terminal?: -> bool
+
+        def terminal!: -> Node
+
+        def letter=: (String | Symbol?) -> Symbol?
+
+        def partial_word?: (Array[String]) -> bool
+
+        def word?: (Array[String]) -> bool
+
+        def []: (Symbol) -> Node
+
+        def []=: (Symbol, Node) -> Node
+
+        def key?: (Symbol) -> bool
+
+        def delete: (Symbol) -> Node?
+
+        alias has_key? key?
+
+        private
+
+        def missing: -> Node
+
+        attr_accessor terminal: bool?
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -50,19 +50,19 @@ module Rambling
 
         private
 
-        def missing: -> Node
-
         attr_accessor terminal: bool?
 
+        def missing: -> Node
+
         # abstract methods
+
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
 
         def partial_word_chars?: (Array[String]) -> bool
 
         def word_chars?: (Array[String]) -> bool
 
         def closest_node: (Array[String]) -> Node
-
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -14,11 +14,13 @@ module Rambling
 
         def initialize: (Symbol?, Node?, ?Hash[Symbol, Node]) -> void
 
+        def add: (Array[Symbol]) -> Node
+
         def children: -> Array[Node]
 
         def first_child: -> Node?
 
-        def match_prefix: (String) { (String) -> void } -> Enumerator[String, void]
+        def match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
 
         def root?: -> bool
 
@@ -44,9 +46,20 @@ module Rambling
 
         alias has_key? key?
 
+
         private
 
         def missing: -> Node
+
+        def partial_word_chars?: (Array[String]) -> bool
+
+        def word_chars?: (Array[String]) -> bool
+
+        def closest_node: (Array[String]) -> Node
+
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
+
+        def compressed?: -> bool
 
         attr_accessor terminal: bool?
       end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -12,7 +12,7 @@ module Rambling
         attr_accessor children_tree: Hash[Symbol, Node]
         attr_accessor parent: Node?
 
-        def initialize: (Symbol?, Node?, ?Hash[Symbol, Node]) -> void
+        def initialize: (?Symbol?, ?Node?, ?Hash[Symbol, Node]) -> void
 
         def add: (Array[Symbol]) -> Node
 
@@ -32,6 +32,8 @@ module Rambling
 
         def letter=: (String | Symbol?) -> Symbol?
 
+        def compressed?: -> bool
+
         def partial_word?: (Array[String]) -> bool
 
         def word?: (Array[String]) -> bool
@@ -46,10 +48,13 @@ module Rambling
 
         alias has_key? key?
 
-
         private
 
         def missing: -> Node
+
+        attr_accessor terminal: bool?
+
+        # abstract methods
 
         def partial_word_chars?: (Array[String]) -> bool
 
@@ -58,10 +63,6 @@ module Rambling
         def closest_node: (Array[String]) -> Node
 
         def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
-
-        def compressed?: -> bool
-
-        attr_accessor terminal: bool?
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -20,7 +20,7 @@ module Rambling
 
         def first_child: -> Node?
 
-        def match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
+        def match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
 
         def root?: -> bool
 
@@ -62,7 +62,7 @@ module Rambling
 
         def closest_node: (Array[String]) -> Node
 
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -2,9 +2,17 @@ module Rambling
   module Trie
     module Nodes
       class Node
+        include Compressible
+        include Enumerable
+        include Comparable
+        include Stringifyable
+        include Inspectable
+
         attr_reader letter: Symbol?
         attr_accessor children_tree: Hash[Symbol, Node]
         attr_accessor parent: Node?
+
+        def initialize: (Symbol?, Node?, ?Hash[Symbol, Node]) -> void
 
         def children: -> Array[Node]
 

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -12,13 +12,13 @@ module Rambling
 
         def new_node: (Symbol) -> Node
 
-        def partial_word_chars?: (Array[String | Symbol]) -> bool
+        def partial_word_chars?: (Array[String]) -> bool
 
-        def word_chars?: (Array[String | Symbol]) -> bool
+        def word_chars?: (Array[String]) -> bool
 
-        def closest_node: (Array[String | Symbol]) -> Node
+        def closest_node: (Array[String]) -> Node
 
-        def children_match_prefix: (Array[String | Symbol]) { (String) -> void } -> Enumerator[String, void]?
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -18,7 +18,7 @@ module Rambling
 
         def closest_node: (Array[String | Symbol]) -> Node
 
-        def children_match_prefix: (Array[String | Symbol]) -> Enumerator[String, void]
+        def children_match_prefix: (Array[String | Symbol]) { (String) -> void } -> Enumerator[String, void]?
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -1,0 +1,25 @@
+module Rambling
+  module Trie
+    module Nodes
+      class Raw < Node
+        def add: (Array[Symbol]) -> Node
+
+        def compressed?: -> bool
+
+        private
+
+        def add_to_children_tree: (Array[Symbol]) -> Node
+
+        def new_node: (Symbol) -> Node
+
+        def partial_word_chars?: (Array[String | Symbol]) -> bool
+
+        def word_chars?: (Array[String | Symbol]) -> bool
+
+        def closest_node: (Array[String | Symbol]) -> Node
+
+        def children_match_prefix: (Array[String | Symbol]) -> Enumerator[String, void]
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -12,13 +12,15 @@ module Rambling
 
         def new_node: (Symbol) -> Node
 
+        # overrides
+
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
+
         def partial_word_chars?: (Array[String]) -> bool
 
         def word_chars?: (Array[String]) -> bool
 
         def closest_node: (Array[String]) -> Node
-
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -18,7 +18,7 @@ module Rambling
 
         def closest_node: (Array[String]) -> Node
 
-        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]?
+        def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
       end
     end
   end

--- a/sig/lib/rambling/trie/readers/plain_text.rbs
+++ b/sig/lib/rambling/trie/readers/plain_text.rbs
@@ -1,0 +1,9 @@
+module Rambling
+  module Trie
+    module Readers
+      class PlainText < Reader
+        def each_word: (String) { (String?) -> void } -> (Enumerator[String?, void] | PlainText)
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/readers/reader.rbs
+++ b/sig/lib/rambling/trie/readers/reader.rbs
@@ -1,0 +1,9 @@
+module Rambling
+  module Trie
+    module Readers
+      class Reader
+        def each_word: (String) { (String) -> void } -> (Enumerator[String, void] | Reader)
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/file.rbs
+++ b/sig/lib/rambling/trie/serializers/file.rbs
@@ -1,0 +1,8 @@
+module Rambling
+  module Trie
+    module Serializers
+      class File < Serializer[String]
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/marshal.rbs
+++ b/sig/lib/rambling/trie/serializers/marshal.rbs
@@ -1,0 +1,13 @@
+module Rambling
+  module Trie
+    module Serializers
+      class Marshal < Serializer[Nodes::Node]
+        @serializer: Serializer[String]
+
+        private
+
+        attr_reader serializer: Serializer[String]
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/serializer.rbs
+++ b/sig/lib/rambling/trie/serializers/serializer.rbs
@@ -1,0 +1,10 @@
+module Rambling
+  module Trie
+    module Serializers
+      class Serializer[TContents]
+        def load: (String) -> TContents
+        def dump: (TContents, String) -> Numeric
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/serializer.rbs
+++ b/sig/lib/rambling/trie/serializers/serializer.rbs
@@ -2,7 +2,7 @@ module Rambling
   module Trie
     module Serializers
       class Serializer[TContents]
-        def load: (String) -> TContents
+        def load: (String) -> TContents?
         def dump: (TContents, String) -> Numeric
       end
     end

--- a/sig/lib/rambling/trie/serializers/serializer.rbs
+++ b/sig/lib/rambling/trie/serializers/serializer.rbs
@@ -2,7 +2,7 @@ module Rambling
   module Trie
     module Serializers
       class Serializer[TContents]
-        def load: (String) -> TContents?
+        def load: (String) -> TContents
         def dump: (TContents, String) -> Numeric
       end
     end

--- a/sig/lib/rambling/trie/serializers/yaml.rbs
+++ b/sig/lib/rambling/trie/serializers/yaml.rbs
@@ -1,0 +1,13 @@
+module Rambling
+  module Trie
+    module Serializers
+      class Yaml < Serializer[Nodes::Node]
+        @serializer: Serializer[String]
+
+        private
+
+        attr_reader serializer: Serializer[String]
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -1,0 +1,19 @@
+module Rambling
+  module Trie
+    module Serializers
+      class Zip < Serializer[Nodes::Node]
+        @properties: Configuration::Properties
+
+        private
+
+        attr_reader properties: Configuration::Properties
+
+        def serializers: -> Configuration::ProviderCollection[Serializer[untyped]]
+
+        def tmp_path: -> String
+
+        def path: (String) -> String
+      end
+    end
+  end
+end

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -4,11 +4,13 @@ module Rambling
       class Zip < Serializer[Nodes::Node]
         @properties: Configuration::Properties
 
+        def initialize: (Configuration::Properties) -> void
+
         private
 
         attr_reader properties: Configuration::Properties
 
-        def serializers: -> Configuration::ProviderCollection[Serializer[untyped]]
+        def serializers: -> Configuration::ProviderCollection[Serializer[Nodes::Node]]
 
         def tmp_path: -> String
 

--- a/sig/lib/rambling/trie/stringifyable.rbs
+++ b/sig/lib/rambling/trie/stringifyable.rbs
@@ -4,6 +4,18 @@ module Rambling
       def as_word: -> String
 
       def to_s: -> String
+
+      private
+
+      # abstract methods
+
+      def letter: -> Symbol
+
+      def terminal?: -> bool
+
+      def parent: -> Nodes::Node?
+
+      def children_tree: -> Hash[Symbol, Nodes::Node]
     end
   end
 end

--- a/sig/lib/rambling/trie/stringifyable.rbs
+++ b/sig/lib/rambling/trie/stringifyable.rbs
@@ -1,0 +1,9 @@
+module Rambling
+  module Trie
+    module Stringifyable
+      def as_word: -> String
+
+      def to_s: -> String
+    end
+  end
+end

--- a/sig/lib/zip/entry.rbs
+++ b/sig/lib/zip/entry.rbs
@@ -1,0 +1,11 @@
+module Zip
+  class Entry
+    include Enumerable[Entry]
+
+    def name: -> String
+
+    def extract: (String) -> void
+
+    def each: ?{ (Entry) -> void } -> (Enumerator[Entry, void])?
+  end
+end

--- a/sig/lib/zip/entry.rbs
+++ b/sig/lib/zip/entry.rbs
@@ -6,6 +6,6 @@ module Zip
 
     def extract: (String) -> void
 
-    def each: ?{ (Entry) -> void } -> (Enumerator[Entry, void])?
+    def each: ?{ (Entry) -> void } -> (Enumerator[Entry, void])
   end
 end

--- a/sig/lib/zip/file.rbs
+++ b/sig/lib/zip/file.rbs
@@ -1,0 +1,11 @@
+module Zip
+  class File
+    CREATE: bool
+
+    def self.open: [TContent] (String, ?bool?) { (File) -> TContent } -> TContent
+
+    def entries: -> Array[Entry]
+
+    def add: (String, String) -> void
+  end
+end

--- a/spec/lib/rambling/trie/nodes/node_spec.rb
+++ b/spec/lib/rambling/trie/nodes/node_spec.rb
@@ -3,7 +3,14 @@
 require 'spec_helper'
 
 describe Rambling::Trie::Nodes::Node do
-  it_behaves_like 'a trie node' do
-    let(:node) { described_class.new }
+  let(:node) { described_class.new }
+
+  it_behaves_like 'a trie node'
+
+  %i(children_match_prefix partial_word_chars? word_chars? closest_node).each do |abstract_method|
+    it "does not implement #{abstract_method} (abstract private method)" do
+      expect { node.send abstract_method, %w(o n e) }
+        .to raise_error NotImplementedError
+    end
   end
 end

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -40,15 +40,16 @@ def compare
 end
 
 def compare_pop_shift_slice
+  a = []
   compare do |bm|
-    a = []
     bm.report('push') { a.push 1 }
-    bm.report('pop') { a.pop }
-
     bm.report('unshift') { a.unshift 1 }
-    bm.report('shift') { a.shift }
-
     bm.report('shovel(<<)') { a << 1 }
+  end
+
+  compare do |bm|
+    bm.report('pop') { a.pop }
+    bm.report('shift') { a.shift }
     bm.report('slice!(0)') { a.slice! 0 }
   end
 end


### PR DESCRIPTION
First:

- Add `rbs` gem and all `rbs` types in `sig/` directory
- Add `steep` gem for easier rbs type checking, with basic configuration only checking `lib` for now
- Add `rubyzip` types as they are not defined

Then:

- Add `|| raise` for places where we expect to always have a value, but that rbs/steep are not smart enough to autodetect
- Add `EMPTY_ENUMERATOR` to be returned when there is no iteration to perform
- Add `_Nilable` interface to allow for `nil?` check on generic type for `ProviderCollection#contains?`
- Expand `ProviderCollection#resolve` to `key?` check to prevent rbs/steep from complaining about `Cannot have body method`
- Add `children_match_prefix` `partial_word_chars?` `word_chars?` `closest_node` private abstract methods to `Nodes::Node`, so that both `Nodes::Raw` and `Nodes::Compressed` have it without duplication
- Make `yardoc` match `rbs` types

Finally:

- Rename `char_symbols` to `reversed_char_symbols` for clarity
- Rename `Nodes::Raw#add`'s param `chars` to `reversed_chars` for clarity
- Add `lint-rbs-steep` action
- Rename `lint` => `lint-rubocop`
- Bump lint and coverage ruby versions to `3.3.6`