### PR TITLE
Fix missing params for enumerator for `Readers::PlainText#each_word`

### DIFF
--- a/lib/rambling/trie/readers/plain_text.rb
+++ b/lib/rambling/trie/readers/plain_text.rb
@@ -10,7 +10,7 @@ module Rambling
         # @yield [String] Each line read from the file.
         # @return [self]
         def each_word filepath
-          return enum_for :each_word unless block_given?
+          return enum_for :each_word, filepath unless block_given?
 
           ::File.foreach(filepath) { |line| yield line.chomp! }
 

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -355,6 +355,12 @@ describe Rambling::Trie::Container do
   describe '#each' do
     before { add_words container, %w(yes no why) }
 
+    it 'yields every word previously added' do
+      yielded = []
+      container.each { |word| yielded << word }
+      expect(yielded).to eq %w(yes no why)
+    end
+
     it 'returns an enumerator when no block is given' do
       expect(container.each).to be_instance_of Enumerator
     end

--- a/spec/lib/rambling/trie/enumerable_spec.rb
+++ b/spec/lib/rambling/trie/enumerable_spec.rb
@@ -15,16 +15,20 @@ module Rambling
           expect(node.each).to be_an Enumerator
         end
 
+        it 'iterates through all words contained in the trie' do
+          expect(node.each.to_a).to match_array words
+        end
+
         it 'has the same word count as the trie' do
           expect(node.count).to eq words.count
         end
 
-        it 'includes every word contained in the trie' do
+        it 'yields every word contained in the trie' do
           node.each { |word| expect(words).to include word }
         end
 
         it 'returns the enumerable when a block is given' do
-          expect(node.each { |_| }).to eq node
+          expect(node.each { |word| print word }).to eq node
         end
       end
 

--- a/spec/lib/rambling/trie/readers/plain_text_spec.rb
+++ b/spec/lib/rambling/trie/readers/plain_text_spec.rb
@@ -15,12 +15,17 @@ describe Rambling::Trie::Readers::PlainText do
       expect(yielded).to eq words
     end
 
-    it 'returns an enumerator when no block is given' do
-      expect(reader.each_word filepath).to be_an Enumerator
+    it 'returns the enumerable when a block is given' do
+      yielded = []
+      expect(reader.each_word(filepath) { |word| yielded << word }).to eq reader
     end
 
-    it 'returns the enumerable when a block is given' do
-      expect(reader.each_word(filepath) { |_| }).to eq reader
+    it 'returns an enumerator when no block is given' do
+      expect(reader.each_word(filepath)).to be_an Enumerator
+    end
+
+    it 'iterates through all words in the given file' do
+      expect(reader.each_word(filepath).to_a).to eq words
     end
   end
 end


### PR DESCRIPTION
Also, ensure we have tests for both yield and enumerator paths where appropriate: `Container#each`, `Enumerable#each`.

Gotta thank the rubocop `Lint/ToEnumArguments` rule for this one!