### PR TITLE
Add `Container#push` to mirror `Array#push` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,16 @@ trie.add 'word'
 trie << 'word'
 ```
 
-Or if you have multiple words to add, you can use `#concat`:
+Or if you have multiple words to add, you can use `#concat` or `#push`:
 
 ``` ruby
 trie.concat %w(a collection of words)
+trie.push 'a', 'collection', 'of', 'words'
+
+# or
+words = %w(a collection of words)
+trie.concat words
+trie.push *words
 ```
 
 And to find out if a word already exists in the trie, use `#word?` or its alias `#include?`:

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -68,6 +68,17 @@ module Rambling
         root.partial_word? word.chars
       end
 
+      # Adds all provided words to the trie.
+      # @param [Array<String>] words the words to add the branch from.
+      # @return [Array<Nodes::Node>] the collection of nodes added.
+      # @raise [InvalidOperation] if the trie is already compressed.
+      # @see #concat
+      # @see Nodes::Raw#add
+      # @see Nodes::Compressed#add
+      def push *words
+        concat words
+      end
+
       # Checks if a whole word exists in the trie.
       # @param [String] word the word to look for in the trie.
       # @return [Boolean] +true+ only if the word is found and the last character corresponds to a terminal node,

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -169,34 +169,22 @@ describe Rambling::Trie::Container do
     end
   end
 
-  describe '#word?' do
-    it_behaves_like 'a propagating node' do
-      let(:method_name) { :word? }
+  describe '#push' do
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'adds all the words to the root node' do
+      container.push 'other', 'words'
+
+      expect(root.children.size).to eq 2
+      expect(root.to_a).to eq %w(other words)
     end
 
-    context 'when word is contained' do
-      before { add_words container, %w(hello high) }
+    it 'returns all the corresponding nodes' do
+      nodes = container.push 'other', 'words'
 
-      it_behaves_like 'a matching container#word'
-
-      context 'with compressed root' do
-        before { container.compress! }
-
-        it_behaves_like 'a matching container#word'
-      end
+      expect(nodes.first.letter).to eq :o
+      expect(nodes.last.letter).to eq :w
     end
-
-    context 'when word is not contained' do
-      before { add_word container, 'hello' }
-
-      it_behaves_like 'a non-matching container#word'
-
-      context 'with compressed root' do
-        before { container.compress! }
-
-        it_behaves_like 'a non-matching container#word'
-      end
-    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe '#partial_word?' do
@@ -227,6 +215,36 @@ describe Rambling::Trie::Container do
         before { container.compress! }
 
         it_behaves_like 'a non-matching container#partial_word'
+      end
+    end
+  end
+
+  describe '#word?' do
+    it_behaves_like 'a propagating node' do
+      let(:method_name) { :word? }
+    end
+
+    context 'when word is contained' do
+      before { add_words container, %w(hello high) }
+
+      it_behaves_like 'a matching container#word'
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        it_behaves_like 'a matching container#word'
+      end
+    end
+
+    context 'when word is not contained' do
+      before { add_word container, 'hello' }
+
+      it_behaves_like 'a non-matching container#word'
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        it_behaves_like 'a non-matching container#word'
       end
     end
   end


### PR DESCRIPTION
And update `README.md` to include `#push` in docs.

Gotta thank rubocop's `Style/ConcatArrayLiterals` rule for the idea here!