### PR TITLE
Upgrade rubocop rules and fix new rule offenses

### DIFF
--- a/.rubocop.disabled.yml
+++ b/.rubocop.disabled.yml
@@ -1,5 +1,22 @@
 # These are all the cops that are disabled in the default configuration.
 
+Capybara/MatchStyle: # new in 2.17
+  Enabled: false
+Capybara/NegationMatcher: # new in 2.14
+  Enabled: false
+Capybara/SpecificActions: # new in 2.14
+  Enabled: false
+Capybara/SpecificFinders: # new in 2.13
+  Enabled: false
+Capybara/SpecificMatcher: # new in 2.12
+  Enabled: false
+FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+  Enabled: false
+FactoryBot/FactoryNameStyle: # new in 2.16
+  Enabled: false
+FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: false
+
 Layout/ClassStructure:
   Description: 'Enforces a configured order of definitions within a class body.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-classes'
@@ -38,6 +55,17 @@ Layout/MultilineAssignmentLayout:
 #   Description: 'Checks unsafe usage of number conversion methods.'
 #   Enabled: false
 
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: false
+RSpec/Rails/HaveHttpStatus: # new in 2.12
+  Enabled: false
+RSpec/Rails/InferredSpecType: # new in 2.14
+  Enabled: false
+RSpec/Rails/MinitestAssertions: # new in 2.17
+  Enabled: false
+RSpec/Rails/TravelAround: # new in 2.19
+  Enabled: false
+
 Style/AutoResourceCleanup:
   Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
   Enabled: false
@@ -45,6 +73,9 @@ Style/AutoResourceCleanup:
 Style/CollectionMethods:
   Description: 'Preferred collection methods.'
   StyleGuide: '#map-find-select-reduce-size'
+  Enabled: false
+
+Style/ConcatArrayLiterals: # new in 1.41
   Enabled: false
 
 Style/Copyright:

--- a/.rubocop.enabled.yml
+++ b/.rubocop.enabled.yml
@@ -1819,3 +1819,246 @@ Style/YodaCondition:
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'
   Enabled: true
+
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: true
+Gemspec/DevelopmentDependencies: # new in 1.44
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessRescue: # new in 1.43
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Metrics/CollectionLiteralLength: # new in 1.47
+  Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Security/IoMethods: # new in 1.22
+  Enabled: true
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
+Style/ComparableClamp: # new in 1.44
+  Enabled: true
+Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DirEmpty: # new in 1.48
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/ExactRegexpMatch: # new in 1.51
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/MapToSet: # new in 1.42
+  Enabled: true
+Style/MinMaxComparison: # new in 1.42
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantConstantBase: # new in 1.40
+  Enabled: true
+Style/RedundantDoubleSplatHashBraces: # new in 1.41
+  Enabled: true
+Style/RedundantEach: # new in 1.38
+  Enabled: true
+Style/RedundantHeredocDelimiterQuotes: # new in 1.45
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/SwapValues: # new in 1.1
+  Enabled: true
+Performance/AncestorsInclude: # new in 1.7
+  Enabled: true
+Performance/BigDecimalWithNumericArgument: # new in 1.7
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock: # new in 1.9
+  Enabled: true
+Performance/CollectionLiteralInLoop: # new in 1.8
+  Enabled: true
+Performance/ConcurrentMonotonicTime: # new in 1.12
+  Enabled: true
+Performance/ConstantRegexp: # new in 1.9
+  Enabled: true
+Performance/MapCompact: # new in 1.11
+  Enabled: true
+Performance/MethodObjectAsBlock: # new in 1.9
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock: # new in 1.10
+  Enabled: true
+Performance/RedundantSortBlock: # new in 1.7
+  Enabled: true
+Performance/RedundantSplitRegexpArgument: # new in 1.10
+  Enabled: true
+Performance/RedundantStringChars: # new in 1.7
+  Enabled: true
+Performance/ReverseFirst: # new in 1.7
+  Enabled: true
+Performance/SortReverse: # new in 1.7
+  Enabled: true
+Performance/Squeeze: # new in 1.7
+  Enabled: true
+Performance/StringIdentifierArgument: # new in 1.13
+  Enabled: true
+Performance/StringInclude: # new in 1.7
+  Enabled: true
+Performance/Sum: # new in 1.8
+  Enabled: true
+RSpec/BeEmpty: # new in 2.20
+  Enabled: true
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11
+  Enabled: true
+RSpec/ContainExactly: # new in 2.19
+  Enabled: true
+RSpec/DuplicatedMetadata: # new in 2.16
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
+RSpec/IndexedLet: # new in 2.20
+  Enabled: true
+RSpec/MatchArray: # new in 2.19
+  Enabled: true
+RSpec/NoExpectationExample: # new in 2.13
+  Enabled: true
+RSpec/PendingWithoutReason: # new in 2.16
+  Enabled: true
+RSpec/RedundantAround: # new in 2.19
+  Enabled: true
+RSpec/SkipBlockInsideExample: # new in 2.19
+  Enabled: true
+RSpec/SortMetadata: # new in 2.14
+  Enabled: true
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,10 +119,10 @@ Layout/LineLength:
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: false
-  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
+  # The AllowedPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
-  # any regular expression listed in this option will be ignored by LineLength.
-  IgnoredPatterns: []
+  # any regular expression listed in this option will be allowed by LineLength.
+  AllowedPatterns: []
 
 Layout/ParameterAlignment:
   # Alignment of parameters in multi-line method calls.
@@ -232,7 +232,7 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   # Number of spaces for each indentation level.
   Width: 2
-  IgnoredPatterns: []
+  AllowedPatterns: []
 
 # Checks the indentation of the first element in an array literal.
 Layout/FirstArrayElementIndentation:
@@ -285,13 +285,14 @@ Layout/FirstHashElementIndentation:
   IndentationWidth: ~
 
 Layout/HeredocIndentation:
-  EnforcedStyle: auto_detection
-  SupportedStyles:
-    - auto_detection
-    - squiggly
-    - active_support
-    - powerpack
-    - unindent
+  Enabled: true
+#  EnforcedStyle: auto_detection
+#  SupportedStyles:
+#    - auto_detection
+#    - squiggly
+#    - active_support
+#    - powerpack
+#    - unindent
 
 Layout/SpaceInLambdaLiteral:
   EnforcedStyle: require_no_space
@@ -706,7 +707,7 @@ Style/BlockDelimiters:
     - let!
     - subject
     - watch
-  IgnoredMethods:
+  AllowedPatterns:
     # Methods that can be either procedural or functional and cannot be
     # categorised from their usage alone, e.g.
     #
@@ -945,7 +946,7 @@ Style/LambdaCall:
 
 Style/MethodCallWithArgsParentheses:
   IgnoreMacros: true
-  IgnoredMethods: []
+  AllowedPatterns: []
 
 Style/MethodDefParentheses:
   # SupportedStyles:
@@ -1189,9 +1190,9 @@ Style/SymbolArray:
     - brackets
 
 Style/SymbolProc:
-  # A list of method names to be ignored by the check.
+  # A list of method names to be allowed by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
-  IgnoredMethods:
+  AllowedMethods:
     - respond_to
     - define_method
 
@@ -1332,7 +1333,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 25
-  ExcludedMethods: []
+  AllowedMethods: []
   Exclude:
     - 'test/**/*'
     - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,11 @@ group :development do
   gem 'flamegraph'
   gem 'memory_profiler'
   gem 'pry'
+  gem 'rake'
+  gem 'rspec'
   gem 'ruby-prof'
   gem 'stackprof'
+  gem 'yard'
 end
 
 group :test do

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -22,6 +22,8 @@ module Rambling
       end
 
       def merge node, other
+        return new_compressed_node node.letter, node.parent, node.children_tree, node.terminal? if other.nil?
+
         letter = node.letter.to_s << other.letter.to_s
 
         new_compressed_node letter.to_sym, node.parent, other.children_tree, other.terminal?

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -46,8 +46,11 @@ module Rambling
         attr_writer :readers, :serializers
 
         def reset_readers
-          plain_text_reader = Rambling::Trie::Readers::PlainText.new
-          @readers = Rambling::Trie::Configuration::ProviderCollection.new :reader, txt: plain_text_reader
+          @readers = Rambling::Trie::Configuration::ProviderCollection.new :reader, default_reader_providers
+        end
+
+        def default_reader_providers
+          { txt: Rambling::Trie::Readers::PlainText.new }
         end
 
         def reset_serializers

--- a/lib/rambling/trie/serializers/file.rb
+++ b/lib/rambling/trie/serializers/file.rb
@@ -17,9 +17,7 @@ module Rambling
         # @param [String] filepath the filepath to dump the contents to.
         # @return [Numeric] number of bytes written to disk.
         def dump contents, filepath
-          ::File.open filepath, 'w+' do |f|
-            f.write contents
-          end
+          ::File.write filepath, contents
         end
       end
     end

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -26,6 +26,8 @@ module Rambling
 
           ::Zip::File.open filepath do |zip|
             entry = zip.entries.first
+            return nil if entry.nil?
+
             entry_path = path entry.name
             entry.extract entry_path
 

--- a/rambling-trie.gemspec
+++ b/rambling-trie.gemspec
@@ -14,19 +14,17 @@ Gem::Specification.new do |gem|
 
   gem.summary = 'A Ruby implementation of the trie data structure.'
   gem.homepage = 'https://github.com/gonzedge/rambling-trie'
-  gem.date = Time.now.strftime '%Y-%m-%d'
   gem.metadata = {
     'changelog_uri' => 'https://github.com/gonzedge/rambling-trie/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://www.rubydoc.info/gems/rambling-trie',
+    'rubygems_mfa_required' => 'true',
   }
 
   executables = `git ls-files -- bin/*`.split "\n"
   files = `git ls-files -- {lib,*file,*.gemspec,LICENSE*,README*}`.split "\n"
-  test_files = `git ls-files -- {test,spec,features}/*`.split "\n"
 
   gem.executables = executables.map { |f| File.basename f }
   gem.files = files
-  gem.test_files = test_files
   gem.require_paths = %w(lib)
 
   gem.name = 'rambling-trie'
@@ -34,8 +32,4 @@ Gem::Specification.new do |gem|
   gem.version = Rambling::Trie::VERSION
   gem.platform = Gem::Platform::RUBY
   gem.required_ruby_version = '>= 2.7', '< 4'
-
-  gem.add_development_dependency 'rake', '~> 13.1'
-  gem.add_development_dependency 'rspec', '~> 3.12'
-  gem.add_development_dependency 'yard', '~> 0.9.34'
 end

--- a/spec/integration/rambling/trie_spec.rb
+++ b/spec/integration/rambling/trie_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 require 'zip'
 
 describe Rambling::Trie do
-  let(:assets_path) { File.join ::SPEC_ROOT, 'assets' }
+  let(:assets_path) { File.join SPEC_ROOT, 'assets' }
 
   describe '::VERSION' do
-    let(:root_path) { File.join ::SPEC_ROOT, '..' }
+    let(:root_path) { File.join SPEC_ROOT, '..' }
     let(:readme_path) { File.join root_path, 'README.md' }
     let(:readme) { File.read readme_path }
     let(:changelog_path) { File.join root_path, 'CHANGELOG.md' }
@@ -94,17 +94,17 @@ describe Rambling::Trie do
     end
 
     context 'when serialized with zipped Ruby marshal format' do
-      let!(:original_on_exists_proc) { ::Zip.on_exists_proc }
-      let!(:original_continue_on_exists_proc) { ::Zip.continue_on_exists_proc }
+      let!(:original_on_exists_proc) { Zip.on_exists_proc }
+      let!(:original_continue_on_exists_proc) { Zip.continue_on_exists_proc }
 
       before do
-        ::Zip.on_exists_proc = true
-        ::Zip.continue_on_exists_proc = true
+        Zip.on_exists_proc = true
+        Zip.continue_on_exists_proc = true
       end
 
       after do
-        ::Zip.on_exists_proc = original_on_exists_proc
-        ::Zip.continue_on_exists_proc = original_continue_on_exists_proc
+        Zip.on_exists_proc = original_on_exists_proc
+        Zip.continue_on_exists_proc = original_continue_on_exists_proc
       end
 
       it_behaves_like 'a serializable trie' do

--- a/spec/lib/rambling/trie/configuration/properties_spec.rb
+++ b/spec/lib/rambling/trie/configuration/properties_spec.rb
@@ -11,17 +11,13 @@ describe Rambling::Trie::Configuration::Properties do
       expect(serializers.formats).to match_array %i(marshal yaml yml zip)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'configures the serializer providers' do
       serializers = properties.serializers
-      expect(serializers.providers.to_a).to match_array [
-        [:marshal, Rambling::Trie::Serializers::Marshal],
-        [:yaml, Rambling::Trie::Serializers::Yaml],
-        [:yml, Rambling::Trie::Serializers::Yaml],
-        [:zip, Rambling::Trie::Serializers::Zip],
-      ]
+      expect(serializers.providers.to_a).to contain_exactly(
+        [:marshal, Rambling::Trie::Serializers::Marshal], [:yaml, Rambling::Trie::Serializers::Yaml],
+        [:yml, Rambling::Trie::Serializers::Yaml], [:zip, Rambling::Trie::Serializers::Zip]
+      )
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it 'configures the reader formats' do
       readers = properties.readers
@@ -30,9 +26,7 @@ describe Rambling::Trie::Configuration::Properties do
 
     it 'configures the reader providers' do
       readers = properties.readers
-      expect(readers.providers.to_a).to match_array [
-        [:txt, Rambling::Trie::Readers::PlainText],
-      ]
+      expect(readers.providers.to_a).to contain_exactly([:txt, Rambling::Trie::Readers::PlainText])
     end
 
     it 'configures the compressor' do

--- a/spec/lib/rambling/trie/configuration/provider_collection_spec.rb
+++ b/spec/lib/rambling/trie/configuration/provider_collection_spec.rb
@@ -9,10 +9,10 @@ describe Rambling::Trie::Configuration::ProviderCollection do
   end
 
   let :first_provider do
-    instance_double 'Rambling::Trie::Serializers::Marshal', :first_provider
+    instance_double Rambling::Trie::Serializers::Marshal, :first_provider
   end
   let :second_provider do
-    instance_double 'Rambling::Trie::Serializers::Marshal', :second_provider
+    instance_double Rambling::Trie::Serializers::Marshal, :second_provider
   end
 
   let :provider_collection do
@@ -73,7 +73,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
 
   describe '#add' do
     let :provider do
-      instance_double 'Rambling::Trie::Serializers::Marshal', :provider
+      instance_double Rambling::Trie::Serializers::Marshal, :provider
     end
 
     before do
@@ -87,7 +87,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
 
   describe '#default=' do
     let :other_provider do
-      instance_double 'Rambling::Trie::Serializers::Marshal', :other_provider
+      instance_double Rambling::Trie::Serializers::Marshal, :other_provider
     end
 
     context 'when the given value is in the providers list' do
@@ -156,7 +156,7 @@ describe Rambling::Trie::Configuration::ProviderCollection do
   describe '#reset' do
     let(:configured_default) { second_provider }
     let :provider do
-      instance_double 'Rambling::Trie::Serializers::Marshal', :provider
+      instance_double Rambling::Trie::Serializers::Marshal, :provider
     end
 
     before do

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -286,14 +286,14 @@ describe Rambling::Trie::Container do
 
     context 'when phrase does not contain any words' do
       it 'returns an empty array' do
-        expect(container.words_within 'xyz').to match_array []
+        expect(container.words_within 'xyz').to be_empty
       end
 
       context 'with compressed node' do
         before { container.compress! }
 
         it 'returns an empty array' do
-          expect(container.words_within 'xyz').to match_array []
+          expect(container.words_within 'xyz').to be_empty
         end
       end
     end

--- a/spec/lib/rambling/trie/readers/plain_text_spec.rb
+++ b/spec/lib/rambling/trie/readers/plain_text_spec.rb
@@ -6,7 +6,7 @@ describe Rambling::Trie::Readers::PlainText do
   subject(:reader) { described_class.new }
 
   describe '#each_word' do
-    let(:filepath) { File.join(::SPEC_ROOT, 'assets', 'test_words.en_US.txt') }
+    let(:filepath) { File.join(SPEC_ROOT, 'assets', 'test_words.en_US.txt') }
     let(:words) { File.readlines(filepath).map(&:chomp) }
 
     it 'yields every word yielded by the file' do

--- a/spec/lib/rambling/trie_spec.rb
+++ b/spec/lib/rambling/trie_spec.rb
@@ -29,7 +29,7 @@ describe Rambling::Trie do
     context 'with a filepath' do
       let(:filepath) { 'a test filepath' }
       let :reader do
-        instance_double 'Rambling::Trie::Readers::PlainText', :reader
+        instance_double Rambling::Trie::Readers::PlainText, :reader
       end
       let(:words) { %w(a couple of test words over here) }
 
@@ -56,7 +56,7 @@ describe Rambling::Trie do
       let(:filepath) { 'a test filepath' }
       let :reader do
         instance_double(
-          'Rambling::Trie::Readers::PlainText',
+          Rambling::Trie::Readers::PlainText,
           :reader,
           each_word: nil,
         )
@@ -84,7 +84,7 @@ describe Rambling::Trie do
     let(:container) { Rambling::Trie::Container.new root, compressor }
     let :serializer do
       instance_double(
-        'Rambling::True::Serializers::File',
+        Rambling::Trie::Serializers::File,
         :serializer,
         load: root,
       )
@@ -103,21 +103,21 @@ describe Rambling::Trie do
     context 'without a serializer' do
       let :marshal_serializer do
         instance_double(
-          'Rambling::Trie::Serializers::Marshal',
+          Rambling::Trie::Serializers::Marshal,
           :marshal_serializer,
           load: nil,
         )
       end
       let :default_serializer do
         instance_double(
-          'Rambling::Trie::Serializers::File',
+          Rambling::Trie::Serializers::File,
           :default_serializer,
           load: nil,
         )
       end
       let :yaml_serializer do
         instance_double(
-          'Rambling::Trie::Serializers::Yaml',
+          Rambling::Trie::Serializers::Yaml,
           :yaml_serializer,
           load: nil,
         )
@@ -167,29 +167,29 @@ describe Rambling::Trie do
 
   describe '.dump' do
     let(:filename) { 'a trie' }
-    let(:root) { instance_double 'Rambling::Trie::Serializers::Marshal', :root }
+    let(:root) { instance_double Rambling::Trie::Serializers::Marshal, :root }
     let :compressor do
-      instance_double 'Rambling::Trie::Serializers::Marshal', :compressor
+      instance_double Rambling::Trie::Serializers::Marshal, :compressor
     end
     let(:trie) { Rambling::Trie::Container.new root, compressor }
 
     let :marshal_serializer do
       instance_double(
-        'Rambling::Trie::Serializers::Marshal',
+        Rambling::Trie::Serializers::Marshal,
         :marshal_serializer,
         dump: nil,
       )
     end
     let :yaml_serializer do
       instance_double(
-        'Rambling::Trie::Serializers::Yaml',
+        Rambling::Trie::Serializers::Yaml,
         :yaml_serializer,
         dump: nil,
       )
     end
     let :default_serializer do
       instance_double(
-        'Rambling::Trie::Serializers::File',
+        Rambling::Trie::Serializers::File,
         :default_serializer,
         dump: nil,
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ end
 
 require 'rspec'
 require 'rambling-trie'
-::SPEC_ROOT = File.dirname __FILE__
+SPEC_ROOT = File.dirname __FILE__
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/shared_examples/a_serializable_trie.rb
+++ b/spec/support/shared_examples/a_serializable_trie.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples_for 'a serializable trie' do
-  let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
+  let(:tmp_path) { File.join SPEC_ROOT, 'tmp' }
   let(:filepath) { File.join tmp_path, "trie-root.#{file_format}" }
 
   context 'with an uncompressed trie' do

--- a/spec/support/shared_examples/a_serializer.rb
+++ b/spec/support/shared_examples/a_serializer.rb
@@ -4,7 +4,7 @@ shared_examples_for 'a serializer' do
   subject(:serializer) { described_class.new }
 
   let(:trie) { Rambling::Trie.create }
-  let(:tmp_path) { File.join ::SPEC_ROOT, 'tmp' }
+  let(:tmp_path) { File.join SPEC_ROOT, 'tmp' }
   let(:filepath) { File.join tmp_path, "trie-root.#{file_format}" }
   let(:content) { trie.root }
 

--- a/spec/support/shared_examples/a_trie_node.rb
+++ b/spec/support/shared_examples/a_trie_node.rb
@@ -74,7 +74,7 @@ shared_examples_for 'a trie node' do
   describe 'delegates and aliases' do
     let :children_tree do
       instance_double(
-        'Hash',
+        Hash,
         :children_tree,
         :[] => 'value',
         :[]= => nil,
@@ -118,8 +118,8 @@ shared_examples_for 'a trie node' do
     # rubocop:disable RSpec/ExampleLength
     it 'delegates `#children` to its children tree values' do
       children = [
-        instance_double('Rambling::Trie::Nodes::Node', :child_one),
-        instance_double('Rambling::Trie::Nodes::Node', :child_two),
+        instance_double(Rambling::Trie::Nodes::Node, :child_one),
+        instance_double(Rambling::Trie::Nodes::Node, :child_two),
       ]
       allow(children_tree).to receive(:values).and_return children
 

--- a/tasks/serialization/regenerate.rb
+++ b/tasks/serialization/regenerate.rb
@@ -48,7 +48,7 @@ module Serialization
       puts "Serializing to '#{filename}'... "
 
       path = File.join tries_path, filename
-      File.delete path if File.exist?(path)
+      FileUtils.rm_f path
       Rambling::Trie.dump trie, path
     end
   end


### PR DESCRIPTION
- Fix newer offenses; remove deprecated rules
- Explicitly disable `RSpec/Rails`, `Capybara` and `Factorybot` rules
- Enable new `Lint`, `Style` and `Rspec` rules
- Remove `add_development_dependency` and `test_files` from `Gemfile`
- Prefer `::File.write` over `::File.open`
- Remove `::` when unnecessary
- Use constants instead of strings for `instance_double`s
- Use `be_empty` instead of `match_array []`
- Prefer `FileUtils.rm_f path` instead of `File.delete if path File.exist?`
- Prefer `contain_exactly` over `match_array`
