### PR TITLE
Ensure only non-root nodes are marked as terminal

### DIFF
--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -11,7 +11,7 @@ module Rambling
         # @note This method clears the contents of the chars variable.
         def add chars
           if chars.empty?
-            terminal!
+            terminal! unless root?
           else
             add_to_children_tree chars
           end

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -34,6 +34,12 @@ describe Rambling::Trie::Container do
       expect(root.children.size).to eq 1
       expect(root.to_a).to eq %w(hello)
     end
+
+    it 'does nothing with empty strings' do
+      add_word container, ''
+      expect(root.children.size).to eq 0
+      expect(root.to_a).to be_empty
+    end
     # rubocop:enable RSpec/MultipleExpectations
   end
 

--- a/spec/lib/rambling/trie/nodes/raw_spec.rb
+++ b/spec/lib/rambling/trie/nodes/raw_spec.rb
@@ -32,6 +32,22 @@ describe Rambling::Trie::Nodes::Raw do
   end
 
   describe '#add' do
+    context 'when the node has no parent' do
+      before { node.parent = nil }
+
+      context 'when adding an empty string' do
+        before { add_word node, '' }
+
+        it 'does not add new children' do
+          expect(node.children.size).to eq 0
+        end
+
+        it 'does not mark itself as terminal' do
+          expect(node).not_to be_terminal
+        end
+      end
+    end
+
     context 'when the node has no branches' do
       before { add_word node, 'abc' }
 

--- a/spec/lib/rambling/trie/stringifyable_spec.rb
+++ b/spec/lib/rambling/trie/stringifyable_spec.rb
@@ -4,13 +4,22 @@ require 'spec_helper'
 
 describe Rambling::Trie::Stringifyable do
   describe '#as_word' do
-    let(:node) { Rambling::Trie::Nodes::Raw.new }
+    let(:parent) { Rambling::Trie::Nodes::Raw.new }
+    let(:node) { Rambling::Trie::Nodes::Raw.new nil, parent }
 
     context 'with an empty node' do
       before { add_word node, '' }
 
       it 'returns nil' do
         expect(node.as_word).to be_empty
+      end
+
+      context 'with no parent' do
+        let(:parent) { nil }
+
+        it 'returns nil' do
+          expect(node.as_word).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
Turns out calling `#add` with an empty string in either `Container` or `Nodes::Raw` currently results in marking the root node as terminal, which is not the expected behavior. This PR fixes that by checking `root?` before calling `terminal!`.