### PR TITLE
Add reek + codeclimate plugin + lint-reek GH action

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,6 +24,8 @@ plugins:
   # Code smells
   reek:
     enabled: true
+    exclude_patterns:
+      - 'spec/'
   # Ruby lint
   rubocop:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,9 @@ plugins:
   # Markdown lint with rules from https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
   markdownlint:
     enabled: true
+  # Code smells
+  reek:
+    enabled: true
   # Ruby lint
   rubocop:
     enabled: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,17 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  lint-rubocop:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.3.6
-          bundler-cache: true
-      - name: Run rubocop
-        run: bundle exec rubocop
   lint-rbs-steep:
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +23,28 @@ jobs:
           bundler-cache: true
       - name: Run rbs + steep
         run: bundle exec steep check
+  lint-reek:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.6
+          bundler-cache: true
+      - name: Run reek
+        run: bundle exec reek
+  lint-rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.6
+          bundler-cache: true
+      - name: Run rubocop
+        run: bundle exec rubocop
   spec:
     runs-on: ubuntu-latest
     strategy:

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,4 +1,17 @@
 ---
 detectors:
+  UnusedParameters:
+    exclude:
+      # Rambling::Trie::Nodes::Node has some abstract methods
+      - 'Rambling::Trie::Nodes::Node#children_match_prefix'
+      - 'Rambling::Trie::Nodes::Node#closest_node'
+      - 'Rambling::Trie::Nodes::Node#partial_word_chars?'
+      - 'Rambling::Trie::Nodes::Node#word_chars?'
+      # Rambling::Trie::Readers::Reader is an abstract class
+      - 'Rambling::Trie::Readers::Reader#each_word'
+      # Rambling::Trie::Serializers::Serializer is an abstract class
+      - 'Rambling::Trie::Serializers::Serializer#dump'
+      - 'Rambling::Trie::Serializers::Serializer#load'
+
   UtilityFunction:
     public_methods_only: true

--- a/.reek.yml
+++ b/.reek.yml
@@ -8,6 +8,11 @@ detectors:
       # All Properties are settable by clients because of config convention
       - 'Rambling::Trie::Configuration::Properties'
 
+  FeatureEnvy:
+    exclude:
+      - 'Rambling::Trie::Compressor' # needs to access node internals to perform compression
+      - 'Rambling::Trie::Nodes::Compressed#partial_word_chars?' # needs access to child letter to figure out compressed letters
+
   NestedIterators:
     exclude:
       - 'Rambling::Trie#create' # inner iteration goes through each word in given file

--- a/.reek.yml
+++ b/.reek.yml
@@ -14,6 +14,9 @@ detectors:
       - 'Rambling::Trie::Container#words_within_root' # inner iteration does a match of each prefix
       - 'Rambling::Trie::Enumerable#each' # inner iteration goes through each word in children_tree
 
+  TooManyStatements:
+    max_statements: 10
+
   UnusedParameters:
     exclude:
       # Rambling::Trie::Nodes::Node has some abstract methods

--- a/.reek.yml
+++ b/.reek.yml
@@ -8,6 +8,9 @@ detectors:
       # All Properties are settable by clients because of config convention
       - 'Rambling::Trie::Configuration::Properties'
 
+  ControlParameter:
+    enabled: false
+
   DuplicateMethodCall:
     exclude:
       # Not actual duplicates, the underlying var is mutated

--- a/.reek.yml
+++ b/.reek.yml
@@ -15,3 +15,7 @@ detectors:
 
   UtilityFunction:
     public_methods_only: true
+    exclude:
+      # Rambling::Trie::Serializers::File are intentionally using ::File methods
+      - 'Rambling::Trie::Serializers::File#dump'
+      - 'Rambling::Trie::Serializers::File#load'

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,4 +1,8 @@
 ---
+exclude_paths:
+  - tasks
+  - spec
+
 detectors:
   Attribute:
     exclude:

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,5 +1,11 @@
 ---
 detectors:
+  NestedIterators:
+    exclude:
+      - 'Rambling::Trie#create' # inner iteration goes through each word in given file
+      - 'Rambling::Trie::Container#words_within_root' # inner iteration does a match of each prefix
+      - 'Rambling::Trie::Enumerable#each' # inner iteration goes through each word in children_tree
+
   UnusedParameters:
     exclude:
       # Rambling::Trie::Nodes::Node has some abstract methods

--- a/.reek.yml
+++ b/.reek.yml
@@ -8,6 +8,11 @@ detectors:
       # All Properties are settable by clients because of config convention
       - 'Rambling::Trie::Configuration::Properties'
 
+  DuplicateMethodCall:
+    exclude:
+      # Not actual duplicates, the underlying var is mutated
+      - 'Rambling::Trie::Nodes::Compressed'
+
   FeatureEnvy:
     exclude:
       - 'Rambling::Trie::Compressor' # needs to access node internals to perform compression

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,5 +1,13 @@
 ---
 detectors:
+  Attribute:
+    exclude:
+      # Need these setters for compression
+      - 'Rambling::Trie::Nodes::Node#children_tree'
+      - 'Rambling::Trie::Nodes::Node#parent'
+      # All Properties are settable by clients because of config convention
+      - 'Rambling::Trie::Configuration::Properties'
+
   NestedIterators:
     exclude:
       - 'Rambling::Trie#create' # inner iteration goes through each word in given file

--- a/.reek.yml
+++ b/.reek.yml
@@ -27,6 +27,10 @@ detectors:
       - 'Rambling::Trie::Container#words_within_root' # inner iteration does a match of each prefix
       - 'Rambling::Trie::Enumerable#each' # inner iteration goes through each word in children_tree
 
+  NilCheck:
+    exclude:
+      - 'Rambling::Trie::Configuration::ProviderCollection#contains?' # necessary for steep type check
+
   TooManyMethods:
     exclude:
       - 'Rambling::Trie::Container' # Container is the lib API entry point

--- a/.reek.yml
+++ b/.reek.yml
@@ -24,6 +24,11 @@ detectors:
       - 'Rambling::Trie::Container#words_within_root' # inner iteration does a match of each prefix
       - 'Rambling::Trie::Enumerable#each' # inner iteration goes through each word in children_tree
 
+  TooManyMethods:
+    exclude:
+      - 'Rambling::Trie::Container' # Container is the lib API entry point
+      - 'Rambling::Trie::Nodes::Node' # Node is the main building block
+
   TooManyStatements:
     max_statements: 10
 

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,4 @@
+---
+detectors:
+  UtilityFunction:
+    public_methods_only: true

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :local do
   gem 'flog', require: false
   gem 'guard-rspec'
   gem 'mdl', require: false
+  gem 'reek', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rake', require: false

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -24,11 +24,13 @@ module Rambling
       end
 
       def merge node, other
-        return new_compressed_node node.letter, node.parent, node.children_tree, node.terminal? unless other
+        letter = node.letter
+        parent = node.parent
 
-        letter = node.letter.to_s << other.letter.to_s
+        return new_compressed_node letter, parent, node.children_tree, node.terminal? unless other
 
-        new_compressed_node letter.to_sym, node.parent, other.children_tree, other.terminal?
+        letter = letter.to_s << other.letter.to_s
+        new_compressed_node letter.to_sym, parent, other.children_tree, other.terminal?
       end
 
       def compress_children_and_copy node

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -8,7 +8,7 @@ module Rambling
       # @param [Nodes::Node] node the node to compress.
       # @return [Nodes::Compressed] node the compressed version of the node.
       def compress node
-        return if node.nil?
+        return unless node
 
         if node.compressible?
           compress_child_and_merge node
@@ -24,7 +24,7 @@ module Rambling
       end
 
       def merge node, other
-        return new_compressed_node node.letter, node.parent, node.children_tree, node.terminal? if other.nil?
+        return new_compressed_node node.letter, node.parent, node.children_tree, node.terminal? unless other
 
         letter = node.letter.to_s << other.letter.to_s
 

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -41,7 +41,8 @@ module Rambling
       end
 
       def compress_children_and_copy node
-        compressed = Rambling::Trie::Nodes::Compressed.new node.letter, node.parent, compress_children(node.children_tree)
+        children_tree = compress_children(node.children_tree)
+        compressed = Rambling::Trie::Nodes::Compressed.new node.letter, node.parent, children_tree
         compressed.terminal! if node.terminal?
         compressed
       end

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -27,14 +27,23 @@ module Rambling
         letter = node.letter
         parent = node.parent
 
-        return new_compressed_node letter, parent, node.children_tree, node.terminal? unless other
+        if other
+          letter = letter.to_s << other.letter.to_s
+          compressed = Rambling::Trie::Nodes::Compressed.new letter.to_sym, parent, other.children_tree
+          terminal = other.terminal?
+        else
+          compressed = Rambling::Trie::Nodes::Compressed.new letter, parent, node.children_tree
+          terminal = node.terminal?
+        end
 
-        letter = letter.to_s << other.letter.to_s
-        new_compressed_node letter.to_sym, parent, other.children_tree, other.terminal?
+        compressed.terminal! if terminal
+        compressed
       end
 
       def compress_children_and_copy node
-        new_compressed_node node.letter, node.parent, compress_children(node.children_tree), node.terminal?
+        compressed = Rambling::Trie::Nodes::Compressed.new node.letter, node.parent, compress_children(node.children_tree)
+        compressed.terminal! if node.terminal?
+        compressed
       end
 
       def compress_children tree
@@ -46,14 +55,6 @@ module Rambling
         end
 
         new_tree
-      end
-
-      def new_compressed_node letter, parent, tree, terminal
-        node = Rambling::Trie::Nodes::Compressed.new letter, parent, tree
-        node.terminal! if terminal
-
-        tree.each_value { |child| child.parent = node }
-        node
       end
     end
   end

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -4,6 +4,7 @@ module Rambling
   module Trie
     module Configuration
       # Provides configurable properties for Rambling::Trie.
+      # :reek:TooManyInstanceVariables { max_instance_variables: 5 }
       class Properties
         # The configured {Readers Readers}.
         # @return [ProviderCollection<Readers::Reader>] the mapping of configured {Readers Readers}.

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -70,7 +70,7 @@ module Rambling
         # @return [void]
         def reset
           providers.clear
-          configured_providers.each { |k, v| self[k] = v }
+          configured_providers.each { |extension, provider| self[extension] = provider }
           self.default = configured_default
         end
 
@@ -111,8 +111,7 @@ module Rambling
         def contains? provider
           return true if provider.nil?
 
-          p = provider || raise
-          providers.any? && provider_instances.include?(p)
+          providers.any? && provider_instances.include?(provider || raise)
         end
 
         alias_method :provider_instances, :values

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -109,7 +109,7 @@ module Rambling
         end
 
         def contains? provider
-          return true unless provider
+          return true if provider.nil?
 
           providers.any? && provider_instances.include?(provider || raise)
         end

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -109,7 +109,7 @@ module Rambling
         end
 
         def contains? provider
-          return true if provider.nil?
+          return true unless provider
 
           providers.any? && provider_instances.include?(provider || raise)
         end

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -217,7 +217,7 @@ module Rambling
 
       def reversed_char_symbols word
         symbols = []
-        word.reverse.each_char { |c| symbols << c.to_sym }
+        word.reverse.each_char { |char| symbols << char.to_sym }
         symbols
       end
     end

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -201,9 +201,10 @@ module Rambling
         return enum_for :words_within_root, phrase unless block_given?
 
         chars = phrase.chars
+        size = chars.length - 1
         # rubocop:disable Style/CommentedKeyword
-        0.upto(chars.length - 1).each do |starting_index|
-          new_phrase = chars.slice starting_index..(chars.length - 1) # : Array[String]
+        0.upto(size).each do |starting_index|
+          new_phrase = chars.slice starting_index..size # : Array[String]
           root.match_prefix new_phrase do |word|
             yield word
           end

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -6,6 +6,17 @@ module Rambling
       # A representation of a node in an compressed trie data structure.
       # :reek:RepeatedConditional { max_ifs: 4 }
       class Compressed < Rambling::Trie::Nodes::Node
+        # Creates a new compressed node.
+        # @param [Symbol, nil] letter the Node's letter value.
+        # @param [Node, nil] parent the parent of the current node.
+        # @param [Hash<Symbol, Node>] children_tree the children tree of the current node.
+        def initialize letter = nil, parent = nil, children_tree = {}
+          super
+
+          # Ensure all children have the current compressed node as the parent
+          children_tree.each_value { |child| child.parent = self }
+        end
+
         # Always raises {Rambling::Trie::InvalidOperation InvalidOperation} when
         # trying to add a word to the current compressed trie node
         # @param [String] _ the word to add to the trie.

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -4,6 +4,7 @@ module Rambling
   module Trie
     module Nodes
       # A representation of a node in an compressed trie data structure.
+      # :reek:RepeatedConditional { max_ifs: 4 }
       class Compressed < Rambling::Trie::Nodes::Node
         # Always raises {Rambling::Trie::InvalidOperation InvalidOperation} when
         # trying to add a word to the current compressed trie node

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -4,6 +4,7 @@ module Rambling
   module Trie
     module Nodes
       # A representation of a node in the trie data structure.
+      # :reek:MissingSafeMethod { exclude: [ terminal! ] }
       class Node
         include Rambling::Trie::Compressible
         include Rambling::Trie::Enumerable

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -5,6 +5,7 @@ module Rambling
     module Nodes
       # A representation of a node in the trie data structure.
       # :reek:MissingSafeMethod { exclude: [ terminal! ] }
+      # :reek:RepeatedConditional { max_ifs: 3 }
       class Node
         include Rambling::Trie::Compressible
         include Rambling::Trie::Enumerable

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -4,6 +4,7 @@ module Rambling
   module Trie
     module Nodes
       # A representation of a node in an uncompressed trie data structure.
+      # :reek:RepeatedConditional { max_ifs: 4 }
       class Raw < Rambling::Trie::Nodes::Node
         # Adds a word to the current raw (uncompressed) trie node.
         # @param [Array<Symbol>] reversed_chars the char array to add to the trie, in reverse order.

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -26,13 +26,13 @@ module Rambling
 
           ::Zip::File.open filepath do |zip|
             entry = zip.entries.first
-            raise if entry.nil?
+            raise unless entry
 
             entry_path = path entry.name
             entry.extract entry_path
 
             serializer = serializers.resolve entry.name
-            raise if serializer.nil?
+            raise unless serializer
 
             serializer.load entry_path
           end
@@ -53,7 +53,7 @@ module Rambling
             entry_path = path filename
             serializer = serializers.resolve filename
 
-            raise if serializer.nil?
+            raise unless serializer
 
             serializer.dump contents, entry_path
 

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -28,10 +28,11 @@ module Rambling
             entry = zip.entries.first
             raise unless entry
 
-            entry_path = path entry.name
+            entry_name = entry.name
+            entry_path = path entry_name
             entry.extract entry_path
 
-            serializer = serializers.resolve entry.name
+            serializer = serializers.resolve entry_name
             raise unless serializer
 
             serializer.load entry_path

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -5,9 +5,9 @@ module Rambling
 
       private
 
-      def compress_child_and_merge: (Nodes::Node) -> Nodes::Compressed
+      def compress_only_child_and_merge: (Nodes::Node) -> Nodes::Compressed
 
-      def merge: (Nodes::Node, Nodes::Node?) -> Nodes::Compressed
+      def merge: (Nodes::Node, Nodes::Node) -> Nodes::Compressed
 
       def compress_children_and_copy: (Nodes::Node) -> Nodes::Compressed
 

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -12,8 +12,6 @@ module Rambling
       def compress_children_and_copy: (Nodes::Node) -> Nodes::Compressed
 
       def compress_children: (Hash[Symbol, Nodes::Node]) -> Hash[Symbol, Nodes::Node]
-
-      def new_compressed_node: (Symbol?, Nodes::Node?, Hash[Symbol, Nodes::Node], bool?) -> Nodes::Compressed
     end
   end
 end

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -2,6 +2,8 @@ module Rambling
   module Trie
     module Nodes
       class Compressed < Node
+        def initialize: (?Symbol?, ?Node?, ?Hash[Symbol, Node]) -> void
+
         def add: (Array[Symbol]) -> Node
 
         def compressed?: -> bool


### PR DESCRIPTION
- Add `reek` gem, exclude `tasks` and `spec` from checks
- Add `.reek.yml` with exclusions
- Add `lint-reek` GitHub action

Code smells addressed:
- Use `return unless variable` instead of `return if variable.nil?` where appropriate, since nil check is a type check
- Extract `size` variable for `chars.length - 1` in `Container#words_within_root`
- Extract `entry_name` for `entry.name` in `Serializers::Zip`
- Use longer variable names within blocks (`char` in `Container#words_within_root`; `extension`, `provider` in `ProviderCollection#reset`) or remove altogether `p` in `ProviderCollection#contains?`

Also:

- Assign `child.parent` to `self` in all of `children_tree` during `Nodes::Compressed#initialize`
- Simplify `Compressor#merge`
- Rename `Compressor#compress{,_only}_child_and_merge`
