### PR TITLE
Use `String#chars` + `Array#map` instead of `String#each_char` + `Array#<<`

### DIFF
--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -217,9 +217,7 @@ module Rambling
       end
 
       def reversed_char_symbols word
-        symbols = []
-        word.reverse.each_char { |char| symbols << char.to_sym }
-        symbols
+        word.reverse.chars.map(&:to_sym).to_a
       end
     end
   end

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :each_char_shovel_vs_chars_map do
+    compare_each_char_shovel_vs_chars_map
+  end
+
   task :string_pop_shift_slice do
     compare_string_pop_shift_slice
   end
@@ -40,6 +44,22 @@ def compare
     yield bm
 
     bm.compare!
+  end
+end
+
+def compare_each_char_shovel_vs_chars_map
+  compare do |bm|
+    word = 'awesome'
+
+    bm.report 'each_char and <<' do
+      symbols = []
+      word.reverse.each_char { |char| symbols << char.to_sym }
+      symbols.to_a
+    end
+
+    bm.report 'chars map' do
+      word.reverse.chars.map(&:to_sym).to_a
+    end
   end
 end
 


### PR DESCRIPTION
... during `Rambling::Trie#create` because this benchmark says it is faster (captured as the `ips:each_char_shovel_vs_chars_map`):

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin23]
Warming up --------------------------------------
    each_char and <<    63.994k i/100ms
           chars map    83.503k i/100ms
Calculating -------------------------------------
    each_char and <<    615.709k (± 5.7%) i/s    (1.62 μs/i) -      3.072M in   5.006314s
           chars map    814.335k (± 2.8%) i/s    (1.23 μs/i) -      4.092M in   5.028563s

Comparison:
           chars map:   814335.0 i/s
    each_char and <<:   615708.6 i/s - 1.32x  slower
```

Result:

```diff
 ==> Creation - `Rambling::Trie.create`
 5 iterations -
-                                5.181516   0.113003   5.294519 (  5.296937)
+                                4.751531   0.114047   4.865578 (  4.866892)
```