### PR TITLE
Use `Array#slice(i, slice_size)` instead `Array#slice(i..j)` of for `Container#words_within`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - 'reports/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
+    - 'tasks/ips.rb'
   TargetRubyVersion: 3.1.0
 
 #################### Layout ###########################
@@ -633,8 +634,6 @@ Style/Alias:
   #   - prefer_alias
   #   - prefer_alias_method
   EnforcedStyle: prefer_alias_method
-  Exclude:
-    - 'tasks/ips.rb'
 
 Style/AndOr:
   # Whether `and` and `or` are banned only in conditionals (conditionals)
@@ -1339,7 +1338,6 @@ Metrics/BlockLength:
   Exclude:
     - 'test/**/*'
     - 'spec/**/*'
-    - 'tasks/ips.rb'
 
 Metrics/BlockNesting:
   CountBlocks: false
@@ -1362,8 +1360,6 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20
-  Exclude:
-    - 'tasks/ips.rb'
 
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
+path = File.join 'rambling', 'trie'
 %w(
   comparable compressible compressor configuration container enumerable inspectable invalid_operation
   readers serializers stringifyable nodes version
-).each do |file|
-  require File.join('rambling', 'trie', file)
-end
+).each { |file| require File.join(path, file) }
 
 # General namespace for all Rambling gems.
 module Rambling
@@ -26,9 +25,7 @@ module Rambling
           if filepath
             reader ||= readers.resolve filepath
             # noinspection RubyMismatchedArgumentType,RubyNilAnalysis
-            (reader || raise).each_word filepath do |word|
-              container << word
-            end
+            (reader || raise).each_word(filepath) { |word| container << word }
           end
 
           yield container if block_given?

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -48,10 +48,7 @@ module Rambling
       def compress_children tree
         new_tree = {}
 
-        tree.each do |letter, child|
-          compressed_child = compress child
-          new_tree[letter] = compressed_child
-        end
+        tree.each { |letter, child| new_tree[letter] = compress child }
 
         new_tree
       end

--- a/lib/rambling/trie/configuration.rb
+++ b/lib/rambling/trie/configuration.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-%w(properties provider_collection).each do |file|
-  require File.join('rambling', 'trie', 'configuration', file)
-end
+path = File.join 'rambling', 'trie', 'configuration'
+%w(properties provider_collection).each { |file| require File.join(path, file) }
 
 module Rambling
   module Trie

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -58,7 +58,7 @@ module Rambling
         # @param [String] filepath the filepath to resolve into a provider.
         # @return [TProvider, nil] the provider for the given file's extension. {#default} if not found.
         def resolve filepath
-          extension = file_extension filepath
+          extension = file_format filepath
           if providers.key? extension
             providers[extension]
           else
@@ -102,7 +102,7 @@ module Rambling
           providers.values
         end
 
-        def file_extension filepath
+        def file_format filepath
           File.extname(filepath).sub(%r{^\.}, '').to_sym
         end
 

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -58,7 +58,7 @@ module Rambling
         # @param [String] filepath the filepath to resolve into a provider.
         # @return [TProvider, nil] the provider for the given file's extension. {#default} if not found.
         def resolve filepath
-          extension = file_format filepath
+          extension = file_extension filepath
           if providers.key? extension
             providers[extension]
           else
@@ -102,10 +102,8 @@ module Rambling
           providers.values
         end
 
-        def file_format filepath
-          format = File.extname filepath
-          format.slice! 0
-          format.to_sym
+        def file_extension filepath
+          File.extname(filepath).sub(%r{^\.}, '').to_sym
         end
 
         def contains? provider

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -125,9 +125,7 @@ module Rambling
       def each
         return enum_for :each unless block_given?
 
-        root.each do |word|
-          yield word
-        end
+        root.each { |word| yield word }
       end
 
       # @return [String] a string representation of the container.
@@ -205,9 +203,7 @@ module Rambling
         # rubocop:disable Style/CommentedKeyword
         0.upto(last_index).each do |starting_index|
           new_phrase = chars.slice starting_index..last_index # : Array[String]
-          root.match_prefix new_phrase do |word|
-            yield word
-          end
+          root.match_prefix(new_phrase) { |word| yield word }
         end # : Enumerator[String, void]
         # rubocop:enable Style/CommentedKeyword
       end

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -199,10 +199,10 @@ module Rambling
         return enum_for :words_within_root, phrase unless block_given?
 
         chars = phrase.chars
-        last_index = chars.length - 1
+        size = chars.length
         # rubocop:disable Style/CommentedKeyword
-        0.upto(last_index).each do |starting_index|
-          new_phrase = chars.slice starting_index..last_index # : Array[String]
+        0.upto(size - 1).each do |starting_index|
+          new_phrase = chars.slice starting_index, size # : Array[String]
           root.match_prefix(new_phrase) { |word| yield word }
         end # : Enumerator[String, void]
         # rubocop:enable Style/CommentedKeyword

--- a/lib/rambling/trie/enumerable.rb
+++ b/lib/rambling/trie/enumerable.rb
@@ -20,11 +20,7 @@ module Rambling
 
         yield as_word if terminal?
 
-        children_tree.each_value do |child|
-          child.each do |word|
-            yield word
-          end
-        end
+        children_tree.each_value { |child| child.each { |word| yield word } }
 
         self
       end

--- a/lib/rambling/trie/nodes.rb
+++ b/lib/rambling/trie/nodes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-%w(node missing compressed raw).each do |file|
-  require File.join('rambling', 'trie', 'nodes', file)
-end
+path = File.join 'rambling', 'trie', 'nodes'
+%w(node missing compressed raw).each { |file| require File.join(path, file) }
 
 module Rambling
   module Trie

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -99,9 +99,7 @@ module Rambling
 
           return EMPTY_ENUMERATOR unless child_letter == letter
 
-          child.match_prefix chars do |word|
-            yield word
-          end
+          child.match_prefix(chars) { |word| yield word }
         end
       end
     end

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -69,14 +69,10 @@ module Rambling
 
           return EMPTY_ENUMERATOR if chars.empty?
 
-          letter = (chars.shift || raise).to_sym
-          child = children_tree[letter]
-
+          child = children_tree[(chars.shift || raise).to_sym]
           return EMPTY_ENUMERATOR unless child
 
-          child.match_prefix chars do |word|
-            yield word
-          end
+          child.match_prefix(chars) { |word| yield word }
         end
       end
     end

--- a/lib/rambling/trie/readers.rb
+++ b/lib/rambling/trie/readers.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-%w(reader plain_text).each do |file|
-  require File.join('rambling', 'trie', 'readers', file)
-end
+path = File.join 'rambling', 'trie', 'readers'
+%w(reader plain_text).each { |file| require File.join(path, file) }
 
 module Rambling
   module Trie

--- a/lib/rambling/trie/serializers.rb
+++ b/lib/rambling/trie/serializers.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-%w(serializer file marshal yaml zip).each do |file|
-  require File.join('rambling', 'trie', 'serializers', file)
-end
+path = File.join 'rambling', 'trie', 'serializers'
+%w(serializer file marshal yaml zip).each { |file| require File.join(path, file) }
 
 module Rambling
   module Trie

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,10 +33,9 @@ end
 
 require 'support/config'
 
+shared_examples_path = File.join 'support', 'shared_examples'
 %w(
   a_compressible_trie a_serializable_trie a_serializer a_trie_data_structure
   a_trie_node a_trie_node_implementation a_container_scan a_container_word
   a_container_partial_word a_container_words_within
-).each do |name|
-  require File.join('support', 'shared_examples', name)
-end
+).each { |name| require File.join(shared_examples_path, name) }

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :string_shovel_plus_interpolation do
+    compare_string_shovel_plus_interpolation
+  end
+
   task :hash_assign_vs_inject do
     compare_hash_assign_vs_inject
   end
@@ -56,6 +60,25 @@ def compare
     yield bm
 
     bm.compare!
+  end
+end
+
+def compare_string_shovel_plus_interpolation
+  compare do |bm|
+    bm.report '<<' do
+      a = 'hey'.chars.join
+      a << 'there'
+    end
+
+    bm.report '+' do
+      a = 'hey'.chars.join
+      a + 'there'
+    end
+
+    bm.report 'interpolation' do
+      a = 'hey'.chars.join
+      "#{a}there"
+    end
   end
 end
 

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :do_end_vs_brackets do
+    compare_do_end_vs_brackets
+  end
+
+  task :nil_check_vs_not do
+    compare_nil_check_vs_not
+  end
+
   task :each_char_shovel_vs_chars_map do
     compare_each_char_shovel_vs_chars_map
   end
@@ -44,6 +52,32 @@ def compare
     yield bm
 
     bm.compare!
+  end
+end
+
+def compare_do_end_vs_brackets
+  compare do |bm|
+    bm.config time: 20, warmup: 5
+    a = [1, 2, 3] * 100
+
+    bm.report('do/end') do
+      a.map do |i|
+        1 <= i
+      end
+    end
+
+    bm.report('{ }') do
+      a.map { |i| 1 <= i }
+    end
+  end
+end
+
+def compare_nil_check_vs_not
+  compare do |bm|
+    value = nil
+
+    bm.report('value.nil?') { value.nil? }
+    bm.report('!value') { !value }
   end
 end
 

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :string_slice_vs_brackets do
+    compare_string_slice_vs_brackets
+  end
+
+  task :slice_vs_brackets do
+    compare_slice_vs_brackets
+  end
+
+  task :assign_variable_vs_not do
+    compare_assign_variable_vs_not
+  end
+
   task :string_shovel_plus_interpolation do
     compare_string_shovel_plus_interpolation
   end
@@ -60,6 +72,76 @@ def compare
     yield bm
 
     bm.compare!
+  end
+end
+
+def compare_string_slice_vs_brackets
+  compare do |bm|
+    bm.config time: 20, warmup: 2
+
+    string = 'a string with many characters to test performance of slice(i, j) vs slice(i..j) vs [i..j]'
+    size = string.size
+
+    bm.report 'slice(i, slice_size)' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      string.slice i, slice_size
+    end
+
+    bm.report 'slice(i..j)' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      string.slice i..(i + slice_size)
+    end
+
+    bm.report '[i..j]' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      string[i..(i + slice_size)]
+    end
+  end
+end
+
+def compare_slice_vs_brackets
+  compare do |bm|
+    bm.config time: 20, warmup: 2
+
+    array = %w(t h i s i s a n a r r a y o f c h a r s t o f i g u r e o u t w h a t i s f a s t)
+    size = array.size
+
+    bm.report 'slice(i, slice_size)' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      array.slice i, slice_size
+    end
+
+    bm.report 'slice(i..j)' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      array.slice i..(i + slice_size)
+    end
+
+    bm.report '[i..j]' do
+      i = Random.rand size
+      slice_size = Random.rand size
+      array[i..(i + slice_size)]
+    end
+  end
+end
+
+def compare_assign_variable_vs_not
+  compare do |bm|
+    bm.config time: 20, warmup: 2
+    a = 1
+
+    bm.report 'assign var' do
+      b = 2
+      a + b
+    end
+
+    bm.report 'no var' do
+      a + 2
+    end
   end
 end
 

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -9,10 +9,6 @@ namespace :ips do
     compare_slice_vs_brackets
   end
 
-  task :assign_variable_vs_not do
-    compare_assign_variable_vs_not
-  end
-
   task :string_shovel_plus_interpolation do
     compare_string_shovel_plus_interpolation
   end
@@ -125,22 +121,6 @@ def compare_slice_vs_brackets
       i = Random.rand size
       slice_size = Random.rand size
       array[i..(i + slice_size)]
-    end
-  end
-end
-
-def compare_assign_variable_vs_not
-  compare do |bm|
-    bm.config time: 20, warmup: 2
-    a = 1
-
-    bm.report 'assign var' do
-      b = 2
-      a + b
-    end
-
-    bm.report 'no var' do
-      a + 2
     end
   end
 end

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :hash_assign_vs_inject do
+    compare_hash_assign_vs_inject
+  end
+
   task :do_end_vs_brackets do
     compare_do_end_vs_brackets
   end
@@ -52,6 +56,26 @@ def compare
     yield bm
 
     bm.compare!
+  end
+end
+
+def compare_hash_assign_vs_inject
+  compare do |bm|
+    a = { hello: 'there', how: 'do', you: 'do', fellow: 'kids' }
+
+    bm.report 'var assign' do
+      new_hash = {}
+      a.each { |key, value| new_hash[key] = "#{value}-new" }
+      new_hash
+    end
+
+    bm.report 'inject' do
+      a.inject({}) { |new_hash, entry| new_hash[entry[0]] = "#{entry[1]}-new"; new_hash }
+    end
+
+    bm.report 'each_with_object' do
+      a.each_with_object({}) { |entry, new_hash| new_hash[entry[0]] = "#{entry[1]}-new" }
+    end
   end
 end
 


### PR DESCRIPTION
For performance improvements in `words_within` lookups, particularly for compressed tries.

Also:
- Use `{ }` for blocks instead of `do/end` when they are one-liners
- Use `String#<<` for `Stringifyable`

Diff only showing significant changes:

```diff
 ==> Creation - `Rambling::Trie.create`
 5 iterations -
-                                4.855819   0.118155   4.973974 (  4.973661)
+                                4.737132   0.141721   4.878853 (  4.881739)

...

 ==> Lookups (compressed trie) - `partial_word?`
 200000 iterations - hi                  true
-                                0.597133   0.011527   0.608660 (  0.609033)
+                                0.553478   0.011539   0.565017 (  0.565341)
 200000 iterations - help                true
-                                0.947303   0.007436   0.954739 (  0.955090)
+                                0.909498   0.007411   0.916909 (  0.921346)
 200000 iterations - beautiful           true
-                                1.850720   0.007841   1.858561 (  1.859102)
+                                1.742425   0.007169   1.749594 (  1.751114)
 200000 iterations - impressionism       true
-                                2.595663   0.017449   2.613112 (  2.634528)
+                                2.399570   0.016534   2.416104 (  2.426225)
 200000 iterations - anthropological     true
-                                2.476745   0.011683   2.488428 (  2.489334)
+                                2.336806   0.011436   2.348242 (  2.350403)

 ==> Lookups (raw trie) - `scan`
 1000 iterations - hi                    495
-                                1.669670   0.007410   1.677080 (  1.677776)
+                                1.613825   0.006021   1.619846 (  1.620073)
 100000 iterations - help                20
-                                6.401990   0.028651   6.430641 (  6.433965)
+                                6.213096   0.038045   6.251141 (  6.266207)
 100000 iterations - beautiful           6
-                                2.633810   0.013970   2.647780 (  2.649642)
+                                2.531497   0.010212   2.541709 (  2.542205)
 200000 iterations - impressionism       2
-                                2.305299   0.009155   2.314454 (  2.315151)
+                                2.217809   0.010369   2.228178 (  2.228652)
 200000 iterations - anthropological     2
-                                2.707591   0.013865   2.721456 (  2.723515)
+                                2.581412   0.011297   2.592709 (  2.593721)

 ==> Lookups (compressed trie) - `scan`
 1000 iterations - hi                    495
-                                1.989818   0.017772   2.007590 (  2.008516)
+                                1.266301   0.006315   1.272616 (  1.273371)
 100000 iterations - help                20
-                                7.352145   0.039439   7.391584 (  7.404561)
+                                4.612061   0.018716   4.630777 (  4.633600)
 100000 iterations - beautiful           6
-                                3.998011   0.017885   4.015896 (  4.018349)
+                                2.443975   0.010005   2.453980 (  2.454463)
 200000 iterations - impressionism       2
-                                5.061880   0.024315   5.086195 (  5.088210)
+                                3.124169   0.016127   3.140296 (  3.141667)
 200000 iterations - anthropological     2
-                                4.759248   0.023515   4.782763 (  4.785032)
+                                2.926261   0.015629   2.941890 (  2.946626)

 ==> Lookups (raw trie) - `words_within`
 100000 iterations - ifdxawesome45someword319
-                                5.715074   0.027992   5.743066 (  5.747358)
+                                5.379928   0.024646   5.404574 (  5.408269)
 100000 iterations - ifdx45someword3awesome19
-                                5.547976   0.020684   5.568660 (  5.570471)
+                                5.236084   0.024005   5.260089 (  5.263362)

 ==> Lookups (compressed trie) - `words_within`
 100000 iterations - ifdxawesome45someword319
-                                8.354888   0.044212   8.399100 (  8.414248)
+                                7.277086   0.034592   7.311678 (  7.325401)
 100000 iterations - ifdx45someword3awesome19
-                                8.178280   0.031825   8.210105 (  8.212958)
+                                7.163164   0.027220   7.190384 (  7.193505)
```

Also, add a few ips benchmarks:

- blocks `do/end` vs `{}` (proves that they are effectively the same)
- presence check with `nil?` vs `!` (proves that they are effectively the same)
- hash `each`+`[]=` vs `inject` vs `each_with_object` (proves that `each`+`[]=` is ≈1.5x faster)
- `String`'s and `Array`'s `slice(i, size)` vs `slice(i..j)` vs `[i..j]` (proves that `slice(i, size)` is ≈1.4x faster)