### PR TITLE
Use rake tasks for all lint actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: 3.3.6
           bundler-cache: true
       - name: Run rbs + steep
-        run: bundle exec steep check
+        run: bundle exec rake steep
   lint-reek:
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +33,7 @@ jobs:
           ruby-version: 3.3.6
           bundler-cache: true
       - name: Run reek
-        run: bundle exec reek
+        run: bundle exec rake reek
   lint-rubocop:
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
           ruby-version: 3.3.6
           bundler-cache: true
       - name: Run rubocop
-        run: bundle exec rubocop
+        run: bundle exec rake rubocop
   spec:
     runs-on: ubuntu-latest
     strategy:
@@ -77,7 +77,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Run rspec
-        run: bundle exec rspec
+        run: bundle exec rake spec
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -90,10 +90,10 @@ jobs:
       - name: Report rspec test coverage to coveralls.io
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: bundle exec rspec
+        run: bundle exec rake spec
       - name: Report rspec test coverage to codeclimate.com
         uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
-          coverageCommand: bundle exec rspec
+          coverageCommand: bundle exec rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+require 'reek/rake/task'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'steep/rake_task'
 
 require 'rambling-trie'
 require_relative 'tasks/performance'
@@ -10,6 +12,8 @@ require_relative 'tasks/serialization'
 require_relative 'tasks/ips'
 
 RSpec::Core::RakeTask.new :spec
+Reek::Rake::Task.new :reek
 RuboCop::RakeTask.new :rubocop
+Steep::RakeTask.new :steep
 
 task default: :spec


### PR DESCRIPTION
Add `steep` and `reek` rake tasks, then use `bundle exec rake <lint>` everywhere