### PR TITLE
Add Dockerfile for consistent isolated benchmark runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:3.3.6
+
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/rambling-trie
+RUN git init
+
+# Copy strictly what is necessary to install dependencies
+COPY Gemfile Gemfile.lock rambling-trie.gemspec ./
+COPY lib ./lib
+
+# Install dependencies
+RUN bundle install
+
+# Copy rest of Ruby and Markdown files
+COPY Rakefile ./
+COPY *.md ./
+COPY assets ./assets
+COPY sig ./sig
+COPY spec ./spec
+COPY tasks ./tasks
+COPY scripts ./scripts
+
+# Copy rest of configuration files
+COPY *file ./
+COPY *.yml ./
+COPY .mdl* ./
+COPY .yardopts ./

--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -1,0 +1,28 @@
+FROM ruby:3.3.6
+
+ARG VERSION=2.5.0
+ARG FROM_GITHUB=false
+
+WORKDIR /usr/rambling-trie
+RUN git init
+
+# Generate benchmark-specific minimal Gemfile
+RUN echo "source 'https://rubygems.org'\n\ngem 'rake'\ngem 'rubyzip'\n" > Gemfile && \
+  if [ "$FROM_GITHUB" = "false" ]; \
+  then echo "gem 'rambling-trie', '=$VERSION'" >> Gemfile; \
+  else echo "gem 'rambling-trie', github: 'gonzedge/rambling-trie', ref: '$VERSION'" >> Gemfile; \
+  fi
+
+# Install dependencies
+RUN bundle install
+
+# Copy only what is necessary to run a benchmark
+COPY assets ./assets
+COPY tasks ./tasks
+
+# Generate minimal Rakefile
+RUN echo "# frozen_string_literal: true\n\n" > Rakefile && \
+  echo "require 'rambling-trie'\n" >> Rakefile && \
+  echo "require_relative 'tasks/performance'\n" >> Rakefile && \
+  echo "require_relative 'tasks/serialization'\n" >> Rakefile && \
+  echo "require_relative 'tasks/ips'\n" >> Rakefile

--- a/tasks/helpers/path.rb
+++ b/tasks/helpers/path.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module Helpers
   module Path
     def path *filename_pieces


### PR DESCRIPTION
- Add top-level `Dockerfile` with all relevant files, including `sig/` and `spec/` to run any commands
- Add minimal `Dockerfile.benchmark` with only what is required to run a benchmark (minimal `Gemfile` and minimal `Rakefile`) and with the ability to run on a specific `rambling-trie` version, even from the git repo(!)
- Require `pathname` explicitly in `tasks/helpers/path.rb` so that the benchmark can actually run with the minimal config