### PR TITLE
Add GC-free benchmark reports for versions back to `v2.1.1`

### DIFF
--- a/reports/2.1.1/benchmark
+++ b/reports/2.1.1/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.1.1
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.289745   0.066997   2.356742 (  2.357029)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.420067   0.000000   1.420067 (  1.420343)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.456563   0.013002   1.469565 (  1.469663)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.842739   0.007990   0.850729 (  0.850906)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.092597   0.000000   0.092597 (  0.092602)
+200000 iterations - help                true      
+                                0.165355   0.000001   0.165356 (  0.165363)
+200000 iterations - beautiful           true      
+                                0.322792   0.000894   0.323686 (  0.323723)
+200000 iterations - impressionism       true      
+                                0.456464   0.000000   0.456464 (  0.456519)
+200000 iterations - anthropological     true      
+                                0.513472   0.000000   0.513472 (  0.513550)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.141375   0.000000   0.141375 (  0.141397)
+200000 iterations - help                true      
+                                0.276995   0.000007   0.277002 (  0.277010)
+200000 iterations - beautiful           true      
+                                0.515049   0.000002   0.515051 (  0.515103)
+200000 iterations - impressionism       true      
+                                0.732107   0.000003   0.732110 (  0.732153)
+200000 iterations - anthropological     true      
+                                0.798775   0.000896   0.799671 (  0.799729)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.084839   0.000000   0.084839 (  0.085455)
+200000 iterations - help                true      
+                                0.154294   0.000000   0.154294 (  0.154386)
+200000 iterations - beautiful           true      
+                                0.309226   0.000000   0.309226 (  0.309244)
+200000 iterations - impressionism       true      
+                                0.437260   0.000003   0.437263 (  0.437322)
+200000 iterations - anthropological     true      
+                                0.504585   0.000000   0.504585 (  0.504638)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.162185   0.000003   0.162188 (  0.162223)
+200000 iterations - help                true      
+                                0.301200   0.000003   0.301203 (  0.301236)
+200000 iterations - beautiful           true      
+                                0.603016   0.000003   0.603019 (  0.603097)
+200000 iterations - impressionism       true      
+                                0.847707   0.000850   0.848557 (  0.848641)
+200000 iterations - anthropological     true      
+                                0.801246   0.038982   0.840228 (  0.840311)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                0.765001   0.000003   0.765004 (  0.765047)
+100000 iterations - help                20        
+                                3.280885   0.070989   3.351874 (  3.352104)
+100000 iterations - beautiful           6         
+                                1.313313   0.062922   1.376235 (  1.385929)
+200000 iterations - impressionism       2         
+                                1.173089   0.061968   1.235057 (  1.235190)
+200000 iterations - anthropological     2         
+                                1.365524   0.062992   1.428516 (  1.428719)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.524768   0.000016   0.524784 (  0.524813)
+100000 iterations - help                20        
+                                2.016497   0.000000   2.016497 (  2.018308)
+100000 iterations - beautiful           6         
+                                1.160369   0.000000   1.160369 (  1.160477)
+200000 iterations - impressionism       2         
+                                1.503219   0.000000   1.503219 (  1.503346)
+200000 iterations - anthropological     2         
+                                1.481664   0.004935   1.486599 (  1.490917)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.170008   0.000006   3.170014 (  3.170297)
+100000 iterations - ifdx45someword3awesome19        
+                                3.109764   0.000014   3.109778 (  3.109956)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                4.305075   0.004953   4.310028 (  4.319103)
+100000 iterations - ifdx45someword3awesome19        
+                                4.425574   0.000018   4.425592 (  4.425927)

--- a/reports/2.2.0/benchmark
+++ b/reports/2.2.0/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.2.0
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.356663   0.113971   2.470634 (  2.470811)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.495721   0.001010   1.496731 (  1.496996)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.497632   0.052984   1.550616 (  1.550733)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.859059   0.011005   0.870064 (  0.870403)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.097809   0.000000   0.097809 (  0.097810)
+200000 iterations - help                true      
+                                0.174139   0.000003   0.174142 (  0.174179)
+200000 iterations - beautiful           true      
+                                0.341692   0.000000   0.341692 (  0.341713)
+200000 iterations - impressionism       true      
+                                0.483753   0.000000   0.483753 (  0.483783)
+200000 iterations - anthropological     true      
+                                0.555566   0.000000   0.555566 (  0.555597)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.146911   0.000000   0.146911 (  0.146930)
+200000 iterations - help                true      
+                                0.269491   0.000000   0.269491 (  0.269531)
+200000 iterations - beautiful           true      
+                                0.556360   0.000004   0.556364 (  0.556384)
+200000 iterations - impressionism       true      
+                                0.780389   0.000000   0.780389 (  0.780433)
+200000 iterations - anthropological     true      
+                                0.842368   0.034957   0.877325 (  0.883950)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.136934   0.000000   0.136934 (  0.136958)
+200000 iterations - help                true      
+                                0.158795   0.000000   0.158795 (  0.158819)
+200000 iterations - beautiful           true      
+                                0.319786   0.000000   0.319786 (  0.319880)
+200000 iterations - impressionism       true      
+                                0.457303   0.000989   0.458292 (  0.458371)
+200000 iterations - anthropological     true      
+                                0.563265   0.000008   0.563273 (  0.563374)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.164423   0.000008   0.164431 (  0.164452)
+200000 iterations - help                true      
+                                0.313163   0.000005   0.313168 (  0.313209)
+200000 iterations - beautiful           true      
+                                0.678164   0.000026   0.678190 (  0.678223)
+200000 iterations - impressionism       true      
+                                0.872301   0.027002   0.899303 (  0.899404)
+200000 iterations - anthropological     true      
+                                0.820033   0.089983   0.910016 (  0.910107)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                0.776568   0.000000   0.776568 (  0.776616)
+100000 iterations - help                20        
+                                3.475125   0.131921   3.607046 (  3.611285)
+100000 iterations - beautiful           6         
+                                1.340595   0.124962   1.465557 (  1.465870)
+200000 iterations - impressionism       2         
+                                1.225712   0.127020   1.352732 (  1.352826)
+200000 iterations - anthropological     2         
+                                1.449364   0.124962   1.574326 (  1.574501)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.539915   0.000000   0.539915 (  0.539921)
+100000 iterations - help                20        
+                                2.089176   0.000000   2.089176 (  2.089314)
+100000 iterations - beautiful           6         
+                                1.419128   0.015941   1.435069 (  1.440152)
+200000 iterations - impressionism       2         
+                                2.164169   0.000000   2.164169 (  2.164619)
+200000 iterations - anthropological     2         
+                                1.791854   0.000000   1.791854 (  1.791976)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.295460   0.000002   3.295462 (  3.295673)
+100000 iterations - ifdx45someword3awesome19        
+                                3.324836   0.018963   3.343799 (  3.348187)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                4.544202   0.005002   4.549204 (  4.549626)
+100000 iterations - ifdx45someword3awesome19        
+                                5.198185   0.027017   5.225202 (  5.231402)

--- a/reports/2.2.1/benchmark
+++ b/reports/2.2.1/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.2.1
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.421259   0.128975   2.550234 (  2.550542)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.506011   0.000016   1.506027 (  1.506158)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.467719   0.042991   1.510710 (  1.510777)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.852594   0.010994   0.863588 (  0.863850)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.098796   0.000000   0.098796 (  0.098805)
+200000 iterations - help                true      
+                                0.176295   0.000000   0.176295 (  0.176333)
+200000 iterations - beautiful           true      
+                                0.350677   0.000003   0.350680 (  0.350699)
+200000 iterations - impressionism       true      
+                                0.492486   0.000886   0.493372 (  0.493405)
+200000 iterations - anthropological     true      
+                                0.571883   0.000001   0.571884 (  0.571955)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.147333   0.000008   0.147341 (  0.147351)
+200000 iterations - help                true      
+                                0.271303   0.000000   0.271303 (  0.271347)
+200000 iterations - beautiful           true      
+                                0.558480   0.000000   0.558480 (  0.558525)
+200000 iterations - impressionism       true      
+                                0.781363   0.000000   0.781363 (  0.781411)
+200000 iterations - anthropological     true      
+                                0.848008   0.015943   0.863951 (  0.869327)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.090215   0.000004   0.090219 (  0.090229)
+200000 iterations - help                true      
+                                0.163773   0.000000   0.163773 (  0.163802)
+200000 iterations - beautiful           true      
+                                0.326314   0.000007   0.326321 (  0.326361)
+200000 iterations - impressionism       true      
+                                0.456984   0.000003   0.456987 (  0.457037)
+200000 iterations - anthropological     true      
+                                0.568357   0.000000   0.568357 (  0.568424)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.166651   0.000000   0.166651 (  0.166667)
+200000 iterations - help                true      
+                                0.313791   0.000000   0.313791 (  0.313836)
+200000 iterations - beautiful           true      
+                                0.650077   0.000002   0.650079 (  0.650096)
+200000 iterations - impressionism       true      
+                                0.880654   0.046983   0.927637 (  0.927703)
+200000 iterations - anthropological     true      
+                                0.852862   0.110963   0.963825 (  0.963885)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                0.778745   0.000022   0.778767 (  0.778803)
+100000 iterations - help                20        
+                                3.469652   0.364880   3.834532 (  3.839819)
+100000 iterations - beautiful           6         
+                                1.398977   0.417932   1.816909 (  1.817753)
+200000 iterations - impressionism       2         
+                                1.298358   0.351942   1.650300 (  1.650513)
+200000 iterations - anthropological     2         
+                                1.637852   0.468150   2.106002 (  2.106147)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.547701   0.001581   0.549282 (  0.564510)
+100000 iterations - help                20        
+                                2.106820   0.000000   2.106820 (  2.106950)
+100000 iterations - beautiful           6         
+                                1.409553   0.000015   1.409568 (  1.409662)
+200000 iterations - impressionism       2         
+                                2.128870   0.000000   2.128870 (  2.130342)
+200000 iterations - anthropological     2         
+                                1.802331   0.000000   1.802331 (  1.802410)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.287657   0.001015   3.288672 (  3.293722)
+100000 iterations - ifdx45someword3awesome19        
+                                3.249929   0.000983   3.250912 (  3.251116)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                4.576105   0.008000   4.584105 (  4.585554)
+100000 iterations - ifdx45someword3awesome19        
+                                5.167099   0.011003   5.178102 (  5.178421)

--- a/reports/2.3.0/benchmark
+++ b/reports/2.3.0/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.3.0
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.596670   0.165842   2.762512 (  2.767699)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.644960   0.051999   1.696959 (  1.697162)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.666395   0.073971   1.740366 (  1.740463)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.956825   0.013003   0.969828 (  0.969903)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.103455   0.001983   0.105438 (  0.105438)
+200000 iterations - help                true      
+                                0.174516   0.010015   0.184531 (  0.184539)
+200000 iterations - beautiful           true      
+                                0.360429   0.013981   0.374410 (  0.374439)
+200000 iterations - impressionism       true      
+                                0.504647   0.017988   0.522635 (  0.522685)
+200000 iterations - anthropological     true      
+                                0.592186   0.020972   0.613158 (  0.616257)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.160294   0.000012   0.160306 (  0.160336)
+200000 iterations - help                true      
+                                0.283231   0.000000   0.283231 (  0.283263)
+200000 iterations - beautiful           true      
+                                0.565929   0.013983   0.579912 (  0.579947)
+200000 iterations - impressionism       true      
+                                0.839855   0.037991   0.877846 (  0.877899)
+200000 iterations - anthropological     true      
+                                0.914729   0.029991   0.944720 (  0.944787)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.095026   0.000002   0.095028 (  0.095048)
+200000 iterations - help                true      
+                                0.168627   0.000000   0.168627 (  0.168647)
+200000 iterations - beautiful           true      
+                                0.339997   0.000000   0.339997 (  0.340024)
+200000 iterations - impressionism       true      
+                                0.472893   0.000002   0.472895 (  0.472942)
+200000 iterations - anthropological     true      
+                                0.535177   0.000011   0.535188 (  0.535238)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.190498   0.000000   0.190498 (  0.190525)
+200000 iterations - help                true      
+                                0.352660   0.002982   0.355642 (  0.355671)
+200000 iterations - beautiful           true      
+                                0.724857   0.067979   0.792836 (  0.792874)
+200000 iterations - impressionism       true      
+                                1.086365   0.066001   1.152366 (  1.152459)
+200000 iterations - anthropological     true      
+                                1.108851   0.043992   1.152843 (  1.152948)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                1.070853   0.000009   1.070862 (  1.070978)
+100000 iterations - help                20        
+                                4.902793   0.153995   5.056788 (  5.057142)
+100000 iterations - beautiful           6         
+                                2.272418   0.093974   2.366392 (  2.366524)
+200000 iterations - impressionism       2         
+                                2.137267   0.067943   2.205210 (  2.207898)
+200000 iterations - anthropological     2         
+                                2.613678   0.092021   2.705699 (  2.705854)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.734946   0.000007   0.734953 (  0.735042)
+100000 iterations - help                20        
+                                2.793941   0.000027   2.793968 (  2.794137)
+100000 iterations - beautiful           6         
+                                1.600786   0.072921   1.673707 (  1.680567)
+200000 iterations - impressionism       2         
+                                2.280621   0.170957   2.451578 (  2.451703)
+200000 iterations - anthropological     2         
+                                2.447109   0.113995   2.561104 (  2.561315)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.875454   0.009019   3.884473 (  3.885103)
+100000 iterations - ifdx45someword3awesome19        
+                                3.843031   0.039026   3.882057 (  3.882353)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                5.317820   0.146936   5.464756 (  5.467320)
+100000 iterations - ifdx45someword3awesome19        
+                                6.044861   0.238984   6.283845 (  6.284249)

--- a/reports/2.3.1/benchmark
+++ b/reports/2.3.1/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.3.1
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.909447   0.140950   3.050397 (  3.059386)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.819084   0.050001   1.869085 (  1.869300)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                2.230509   0.056988   2.287497 (  2.287750)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.282666   0.020944   1.303610 (  1.315209)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.121228   0.002006   0.123234 (  0.123270)
+200000 iterations - help                true      
+                                0.227319   0.007981   0.235300 (  0.235651)
+200000 iterations - beautiful           true      
+                                0.426691   0.014991   0.441682 (  0.441717)
+200000 iterations - impressionism       true      
+                                0.596749   0.018019   0.614768 (  0.614822)
+200000 iterations - anthropological     true      
+                                0.661190   0.026977   0.688167 (  0.688215)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.178119   0.000005   0.178124 (  0.178135)
+200000 iterations - help                true      
+                                0.313081   0.000006   0.313087 (  0.313130)
+200000 iterations - beautiful           true      
+                                0.645638   0.006995   0.652633 (  0.652661)
+200000 iterations - impressionism       true      
+                                0.933097   0.025002   0.958099 (  0.958159)
+200000 iterations - anthropological     true      
+                                1.030709   0.027992   1.058701 (  1.058770)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.110526   0.000000   0.110526 (  0.110552)
+200000 iterations - help                true      
+                                0.195055   0.000000   0.195055 (  0.195072)
+200000 iterations - beautiful           true      
+                                0.401257   0.000009   0.401266 (  0.401294)
+200000 iterations - impressionism       true      
+                                0.556979   0.000005   0.556984 (  0.557015)
+200000 iterations - anthropological     true      
+                                0.622127   0.000000   0.622127 (  0.622148)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.234292   0.000000   0.234292 (  0.234301)
+200000 iterations - help                true      
+                                0.466228   0.000997   0.467225 (  0.467254)
+200000 iterations - beautiful           true      
+                                0.936267   0.051971   0.988238 (  0.988283)
+200000 iterations - impressionism       true      
+                                1.353328   0.045004   1.398332 (  1.398479)
+200000 iterations - anthropological     true      
+                                1.323306   0.048977   1.372283 (  1.372363)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                1.329615   0.000001   1.329616 (  1.329683)
+100000 iterations - help                20        
+                                6.098998   0.170868   6.269866 (  6.282620)
+100000 iterations - beautiful           6         
+                                2.788206   0.090998   2.879204 (  2.879498)
+200000 iterations - impressionism       2         
+                                2.545053   0.086968   2.632021 (  2.632239)
+200000 iterations - anthropological     2         
+                                3.052114   0.261823   3.313937 (  3.322142)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                1.001752   0.000005   1.001757 (  1.001831)
+100000 iterations - help                20        
+                                3.802837   0.000039   3.802876 (  3.803232)
+100000 iterations - beautiful           6         
+                                2.131044   0.082906   2.213950 (  2.222673)
+200000 iterations - impressionism       2         
+                                2.823851   0.138973   2.962824 (  2.963739)
+200000 iterations - anthropological     2         
+                                2.878353   0.107972   2.986325 (  2.986641)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                4.490879   0.023067   4.513946 (  4.526354)
+100000 iterations - ifdx45someword3awesome19        
+                                4.439614   0.043017   4.482631 (  4.483038)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                6.362005   0.173917   6.535922 (  6.550860)
+100000 iterations - ifdx45someword3awesome19        
+                                7.126720   0.219929   7.346649 (  7.352650)

--- a/reports/2.4.0/benchmark
+++ b/reports/2.4.0/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.4.0
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.629526   0.284839   2.914365 (  2.920659)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.619587   0.057987   1.677574 (  1.677729)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.724859   0.049002   1.773861 (  1.774015)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.996128   0.013014   1.009142 (  1.009217)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.099642   0.006025   0.105667 (  0.105671)
+200000 iterations - help                true      
+                                0.179197   0.003969   0.183166 (  0.183173)
+200000 iterations - beautiful           true      
+                                0.363472   0.011020   0.374492 (  0.374541)
+200000 iterations - impressionism       true      
+                                0.503594   0.017985   0.521579 (  0.521659)
+200000 iterations - anthropological     true      
+                                0.602530   0.024785   0.627315 (  0.635486)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.160230   0.000012   0.160242 (  0.160245)
+200000 iterations - help                true      
+                                0.284755   0.000035   0.284790 (  0.285021)
+200000 iterations - beautiful           true      
+                                0.584539   0.008027   0.592566 (  0.592791)
+200000 iterations - impressionism       true      
+                                0.852183   0.022973   0.875156 (  0.875454)
+200000 iterations - anthropological     true      
+                                0.899509   0.089996   0.989505 (  0.989649)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.093825   0.000000   0.093825 (  0.093829)
+200000 iterations - help                true      
+                                0.165963   0.001000   0.166963 (  0.167090)
+200000 iterations - beautiful           true      
+                                0.339816   0.000037   0.339853 (  0.340011)
+200000 iterations - impressionism       true      
+                                0.469426   0.000000   0.469426 (  0.469470)
+200000 iterations - anthropological     true      
+                                0.533222   0.000000   0.533222 (  0.533477)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.193058   0.000000   0.193058 (  0.193195)
+200000 iterations - help                true      
+                                0.355882   0.002009   0.357891 (  0.357944)
+200000 iterations - beautiful           true      
+                                0.749699   0.037986   0.787685 (  0.787830)
+200000 iterations - impressionism       true      
+                                1.103475   0.085003   1.188478 (  1.188555)
+200000 iterations - anthropological     true      
+                                1.085488   0.157734   1.243222 (  1.258543)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                1.044620   0.000045   1.044665 (  1.044918)
+100000 iterations - help                20        
+                                4.855682   0.306945   5.162627 (  5.163054)
+100000 iterations - beautiful           6         
+                                2.286114   0.224919   2.511033 (  2.511125)
+200000 iterations - impressionism       2         
+                                2.151644   0.226838   2.378482 (  2.384073)
+200000 iterations - anthropological     2         
+                                2.606554   0.252929   2.859483 (  2.859830)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.736301   0.000000   0.736301 (  0.736340)
+100000 iterations - help                20        
+                                2.805775   0.000025   2.805800 (  2.805963)
+100000 iterations - beautiful           6         
+                                1.610978   0.082899   1.693877 (  1.699046)
+200000 iterations - impressionism       2         
+                                2.287450   0.143011   2.430461 (  2.430734)
+200000 iterations - anthropological     2         
+                                2.430175   0.125008   2.555183 (  2.555663)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.743598   0.025033   3.768631 (  3.774001)
+100000 iterations - ifdx45someword3awesome19        
+                                3.727276   0.040014   3.767290 (  3.767671)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                5.318318   0.194249   5.512567 (  5.517733)
+100000 iterations - ifdx45someword3awesome19        
+                                6.037692   0.256939   6.294631 (  6.295345)

--- a/reports/2.5.0/benchmark
+++ b/reports/2.5.0/benchmark
@@ -1,0 +1,117 @@
+Regenerating serialized dictionary 'espanol'... 
+Serializing to 'espanol_raw.marshal'... 
+Serializing to 'espanol_raw.marshal.zip'... 
+Serializing to 'espanol_compressed.marshal'... 
+Serializing to 'espanol_compressed.marshal.zip'... 
+DONE
+
+Regenerating serialized dictionary 'words_with_friends'... 
+Serializing to 'words_with_friends_raw.marshal'... 
+Serializing to 'words_with_friends_raw.marshal.zip'... 
+Serializing to 'words_with_friends_compressed.marshal'... 
+Serializing to 'words_with_friends_compressed.marshal.zip'... 
+DONE
+
+
+Benchmarks for rambling-trie version 2.5.0
+
+
+==> Creation - `Rambling::Trie.create`
+5 iterations -                                    
+                                2.652750   0.275943   2.928693 (  2.942632)
+
+==> Compression - `compress!`
+5 iterations -                                    
+                                1.653544   0.065024   1.718568 (  1.718688)
+
+==> Serialization (raw trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                1.691230   0.054012   1.745242 (  1.745368)
+
+==> Serialization (compressed trie) - `Rambling::Trie.load`
+5 iterations -                                    
+                                0.971410   0.009019   0.980429 (  0.980568)
+
+==> Lookups (raw trie) - `word?`
+200000 iterations - hi                  true      
+                                0.103568   0.001983   0.105551 (  0.105570)
+200000 iterations - help                true      
+                                0.180786   0.002992   0.183778 (  0.183785)
+200000 iterations - beautiful           true      
+                                0.364722   0.006990   0.371712 (  0.371736)
+200000 iterations - impressionism       true      
+                                0.502514   0.014020   0.516534 (  0.516560)
+200000 iterations - anthropological     true      
+                                0.585583   0.025950   0.611533 (  0.620968)
+
+==> Lookups (compressed trie) - `word?`
+200000 iterations - hi                  true      
+                                0.159661   0.000000   0.159661 (  0.159675)
+200000 iterations - help                true      
+                                0.279398   0.000971   0.280369 (  0.280405)
+200000 iterations - beautiful           true      
+                                0.563534   0.012021   0.575555 (  0.575686)
+200000 iterations - impressionism       true      
+                                0.839726   0.034989   0.874715 (  0.874802)
+200000 iterations - anthropological     true      
+                                0.901594   0.073978   0.975572 (  0.975615)
+
+==> Lookups (raw trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.094459   0.000000   0.094459 (  0.094472)
+200000 iterations - help                true      
+                                0.167198   0.000000   0.167198 (  0.167223)
+200000 iterations - beautiful           true      
+                                0.335443   0.000977   0.336420 (  0.336439)
+200000 iterations - impressionism       true      
+                                0.466998   0.000003   0.467001 (  0.467060)
+200000 iterations - anthropological     true      
+                                0.530598   0.000000   0.530598 (  0.530662)
+
+==> Lookups (compressed trie) - `partial_word?`
+200000 iterations - hi                  true      
+                                0.186299   0.000012   0.186311 (  0.186338)
+200000 iterations - help                true      
+                                0.345901   0.002998   0.348899 (  0.348991)
+200000 iterations - beautiful           true      
+                                0.739892   0.031995   0.771887 (  0.771920)
+200000 iterations - impressionism       true      
+                                1.058048   0.118990   1.177038 (  1.177109)
+200000 iterations - anthropological     true      
+                                1.084106   0.126993   1.211099 (  1.211142)
+
+==> Lookups (raw trie) - `scan`
+1000 iterations - hi                    495       
+                                1.076668   0.000000   1.076668 (  1.076822)
+100000 iterations - help                20        
+                                5.011412   0.298954   5.310366 (  5.310693)
+100000 iterations - beautiful           6         
+                                2.372614   0.235952   2.608566 (  2.608714)
+200000 iterations - impressionism       2         
+                                2.195397   0.219895   2.415292 (  2.419557)
+200000 iterations - anthropological     2         
+                                2.677130   0.251817   2.928947 (  2.929118)
+
+==> Lookups (compressed trie) - `scan`
+1000 iterations - hi                    495       
+                                0.731959   0.000007   0.731966 (  0.732016)
+100000 iterations - help                20        
+                                2.813799   0.000029   2.813828 (  2.813958)
+100000 iterations - beautiful           6         
+                                1.640538   0.076934   1.717472 (  1.725321)
+200000 iterations - impressionism       2         
+                                2.279074   0.135948   2.415022 (  2.418031)
+200000 iterations - anthropological     2         
+                                2.427147   0.207987   2.635134 (  2.635352)
+
+==> Lookups (raw trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                3.842164   0.017901   3.860065 (  3.873771)
+100000 iterations - ifdx45someword3awesome19        
+                                3.776245   0.038002   3.814247 (  3.814514)
+
+==> Lookups (compressed trie) - `words_within`
+100000 iterations - ifdxawesome45someword319        
+                                5.281685   0.172911   5.454596 (  5.463981)
+100000 iterations - ifdx45someword3awesome19        
+                                5.985793   0.267992   6.253785 (  6.254264)


### PR DESCRIPTION
Use:

- ruby `3.3.6` for rambling-trie `2.5.0`, `2.4.0`, `2.3.1`, `2.3.0` benchmarks
- ruby `3.0.0` for rambling-trie `2.2.1`, `2.2.0` benchmarks
- ruby `2.7.8` for rambling-trie `2.1.1` benchmarks