### PR TITLE
Add type signature information to `README`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
     - Change `Container#[]` to return Nodes::Node[TValue]?
     - Add type annotations for `UnannotatedEmptyCollection`s
     - Raise `InvalidOperation`s when `compress(child)` return nil value which is not supposed to be possible
+- Add type signature information to `README` ([#86][github_pull_86]) by [@gonzedge][github_user_gonzedge]
+  - Add `asdf` as an option to manage ruby versions
+  - Use `./<path>` for links within repo
 
 ## 2.5.1 [compare][compare_v2_5_0_and_v2_5_1]
 
@@ -1259,6 +1262,7 @@ Most of these help with the gem's overall performance.
 [github_pull_82]: https://github.com/gonzedge/rambling-trie/pull/82
 [github_pull_83]: https://github.com/gonzedge/rambling-trie/pull/83
 [github_pull_85]: https://github.com/gonzedge/rambling-trie/pull/85
+[github_pull_86]: https://github.com/gonzedge/rambling-trie/pull/86
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You will need:
 * Ruby 3.1.0 or up
 * RubyGems
 
-See [RVM][rvm], [rbenv][rbenv] or [chruby][chruby] for more information on how to manage Ruby versions.
+See [asdf][asdf], [RVM][rvm], [rbenv][rbenv] or [chruby][chruby] for more information on how to manage Ruby versions.
 
 ### Installation
 
@@ -292,6 +292,11 @@ The Rambling Trie has been tested with the following Ruby versions:
 * 1.9.x (EOL'ed)
 * 1.8.x (EOL'ed)
 
+## Compatible RBS and Steep versions
+
+Type signatures for `Rambling::Trie` are included in the [`sig` directory](./sig)! The current version (`2.5.1`) was
+checked with RBS `2.6.3` and Steep `1.8.3`.
+
 ## Contributing to Rambling Trie
 
 Take a look at the [contributing guide][rambling_trie_contributing_guide] to get started, or fire a question
@@ -316,6 +321,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+[asdf]: https://asdf-vm.com/
 [badge_fury_badge]: https://badge.fury.io/rb/rambling-trie.svg?version=2.5.1
 [badge_fury_link]: https://badge.fury.io/rb/rambling-trie
 [chruby]: https://github.com/postmodern/chruby

--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ trie
 ```
 
 If you want to use a custom file format, you will need to provide a custom `Reader` that defines an `#each_word` method
-that yields each word contained in the file. Look at the [`PlainText` reader][rambling_trie_plain_text_reader] class for
-an example, and at the [Configuration section][rambling_trie_configuration] to see how to add your own custom file
-readers.
+that yields each word contained in the file. Look at the [`PlainText` reader](./lib/rambling/trie/readers/plain_text.rb)
+class for an example, and at the [Configuration section](#configuration) to see how to add your own custom file readers.
 
 ### Operations
 
@@ -299,7 +298,7 @@ checked with RBS `2.6.3` and Steep `1.8.3`.
 
 ## Contributing to Rambling Trie
 
-Take a look at the [contributing guide][rambling_trie_contributing_guide] to get started, or fire a question
+Take a look at the [contributing guide](./CONTRIBUTING.md) to get started, or fire a question
 to [@gonzedge][github_user_gonzedge].
 
 ## License and copyright
@@ -343,9 +342,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 [license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license_link]: https://opensource.org/licenses/mit-license.php
 [marshal]: https://ruby-doc.org/3.3.0/Marshal.html
-[rambling_trie_configuration]: https://github.com/gonzedge/rambling-trie#configuration
-[rambling_trie_contributing_guide]: https://github.com/gonzedge/rambling-trie/blob/main/CONTRIBUTING.md
-[rambling_trie_plain_text_reader]: https://github.com/gonzedge/rambling-trie/blob/main/lib/rambling/trie/readers/plain_text.rb
 [rbenv]: https://github.com/sstephenson/rbenv
 [rubydoc]: http://rubydoc.info/gems/rambling-trie
 [rubydoc_github]: http://rubydoc.info/github/gonzedge/rambling-trie


### PR DESCRIPTION
Also: 

- Add `asdf` as an option to manage ruby versions
- Use `./<path>` for links within repo