### PR TITLE
Add explicit support for Ruby `4.0.x` and `3.4.x`; drop support for `3.1.x`

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: semaphore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Dependency Review
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -15,6 +15,6 @@ jobs:
   lint-markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: DavidAnson/markdownlint-cli2-action@v18
+      - uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: '**/*.md'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           ruby-version: 3.4.9
           bundler-cache: true
-      - name: Report rspec test coverage to coveralls.io
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Run rspec with test coverage
         run: bundle exec rake spec
+      - name: Report test coverage to coveralls.io
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.9
+          ruby-version: 4.0.2
           bundler-cache: true
       - name: Run rbs + steep
         run: bundle exec rake steep
@@ -34,6 +34,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 4.0.2
+          - 4.0.1
+          - 4.0.0
           - 3.4.9
           - 3.4.8
           - 3.4.7
@@ -84,7 +87,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.9
+          ruby-version: 4.0.2
           bundler-cache: true
       - name: Run rspec with test coverage
         run: bundle exec rake spec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -72,7 +72,7 @@ jobs:
           - 3.2.1
           - 3.2.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -83,7 +83,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -65,11 +65,6 @@ jobs:
           - 3.2.2
           - 3.2.1
           - 3.2.0
-          - 3.1.4
-          - 3.1.3
-          - 3.1.2
-          - 3.1.1
-          - 3.1.0
     steps:
       - uses: actions/checkout@v3
       - name: Set up ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.6
+          ruby-version: 3.4.8
           bundler-cache: true
       - name: Run rbs + steep
         run: bundle exec rake steep
@@ -34,6 +34,19 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.4.8
+          - 3.4.7
+          - 3.4.6
+          - 3.4.5
+          - 3.4.4
+          - 3.4.3
+          - 3.4.2
+          - 3.4.1
+          - 3.4.0
+          - 3.3.10
+          - 3.3.9
+          - 3.3.8
+          - 3.3.7
           - 3.3.6
           - 3.3.5
           - 3.3.4
@@ -41,6 +54,10 @@ jobs:
           - 3.3.2
           - 3.3.1
           - 3.3.0
+          - 3.2.10
+          - 3.2.9
+          - 3.2.8
+          - 3.2.7
           - 3.2.6
           - 3.2.5
           - 3.2.4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: Run rbs + steep
         run: bundle exec rake steep
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.4.9
           - 3.4.8
           - 3.4.7
           - 3.4.6
@@ -43,6 +44,7 @@ jobs:
           - 3.4.2
           - 3.4.1
           - 3.4.0
+          - 3.3.11
           - 3.3.10
           - 3.3.9
           - 3.3.8
@@ -54,6 +56,7 @@ jobs:
           - 3.3.2
           - 3.3.1
           - 3.3.0
+          - 3.2.11
           - 3.2.10
           - 3.2.9
           - 3.2.8
@@ -81,7 +84,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.6
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: Report rspec test coverage to coveralls.io
         env:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,12 +13,12 @@ on:
 jobs:
   semgrep:
     name: semgrep
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: semgrep ci

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'tasks/ips.rb'
-  TargetRubyVersion: 3.1.0
+  TargetRubyVersion: 3.2.0
 
 #################### Layout ###########################
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 #### Major
 
-- Update `Serializers::Zip` to work with `rubyzip` `3.x` ([#88][github_pull_88]) by [@gonzedge][github_user_gonzedge]
-  - Use `create:` keyword argument for `Zip::File.open`
-  - Use `destination_directory:` keyword argument for `Entry#extract`
 - Allow `Nodes::Node`s to hold arbitrary values ([#85][github_pull_85]) by [@gonzedge][github_user_gonzedge]
   - Add `value` attribute to `Nodes::Node`
   - Add optional, nilable `value` argument to `Container#add`, `Nodes::Node#add`
@@ -18,6 +15,13 @@
   - Add optional `values` array argument to `Container#concat` corresponding 1:1 to `words`, that passes each word and
     value to `#add` when present
   - Add `value` to `Inspectable#inspect` output, when present
+- Update `Serializers::Zip` to work with `rubyzip` `3.x` ([#88][github_pull_88]) by [@gonzedge][github_user_gonzedge]
+  - Use `create:` keyword argument for `Zip::File.open`
+  - Use `destination_directory:` keyword argument for `Entry#extract`
+- Add explicit support for Ruby `3.4.x` and remove support for `3.1.x` (EOL'd) ([#87][github_pull_87])
+  by [@gonzedge][github_user_gonzedge]
+  - Update min supported version to `3.2.0`
+  - Update `rubocop` target version to `3.2.0`
 
 ### Minor
 
@@ -1282,6 +1286,7 @@ Most of these help with the gem's overall performance.
 [github_pull_83]: https://github.com/gonzedge/rambling-trie/pull/83
 [github_pull_85]: https://github.com/gonzedge/rambling-trie/pull/85
 [github_pull_86]: https://github.com/gonzedge/rambling-trie/pull/86
+[github_pull_87]: https://github.com/gonzedge/rambling-trie/pull/87
 [github_pull_88]: https://github.com/gonzedge/rambling-trie/pull/88
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@
 - Update `Serializers::Zip` to work with `rubyzip` `3.x` ([#88][github_pull_88]) by [@gonzedge][github_user_gonzedge]
   - Use `create:` keyword argument for `Zip::File.open`
   - Use `destination_directory:` keyword argument for `Entry#extract`
-- Add explicit support for Ruby `3.4.x` and remove support for `3.1.x` (EOL'd) ([#87][github_pull_87])
+- Add explicit support for Ruby `4.0.x` and `3.4.x`; drop support for `3.1.x` (EOL'd) ([#87][github_pull_87])
   by [@gonzedge][github_user_gonzedge]
+  - Update max ruby version to `< 5` in gemspec
+  - Add now-non-stdlib gems `benchmark` and `irb`
   - Update min supported version to `3.2.0`
   - Update `rubocop` target version to `3.2.0`
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
 end
 
 group :local do
+  gem 'benchmark', require: false
   gem 'benchmark-ips', require: false
   gem 'flamegraph', require: false
   gem 'flog', require: false
@@ -26,6 +27,7 @@ group :local do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'guard-yard', require: false
+  gem 'irb', require: false
   gem 'mdl', require: false
   gem 'memory_profiler', require: false
   gem 'pry', require: false

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
 [![Documentation Status][inch_ci_badge]][rubydoc]
 [![CodeQL Status][github_action_codeql_badge]][github_action_codeql_link]
 
-[![Code Climate Grade][code_climate_grade_badge]][code_climate_link]
-[![Code Climate Issue Count][code_climate_issues_badge]][code_climate_link]
-
 The Rambling Trie is a Ruby implementation of the [trie data structure][trie_wiki], which includes compression abilities
 and is designed to be very fast to traverse.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and is designed to be very fast to traverse.
 
 You will need:
 
-* Ruby 3.1.0 or up
+* Ruby 3.2.0 or up
 * RubyGems
 
 See [asdf][asdf], [RVM][rvm], [rbenv][rbenv] or [chruby][chruby] for more information on how to manage Ruby versions.
@@ -283,10 +283,10 @@ The Rambling Trie has been tested with the following Ruby versions:
 * 3.4.x
 * 3.3.x
 * 3.2.x
-* 3.1.x
 
 **No longer supported**:
 
+* 3.1.x (EOL'ed)
 * 3.0.x (EOL'ed)
 * 2.7.x (EOL'ed)
 * 2.6.x (EOL'ed)

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ want edge documentation, you can go the [GitHub project RubyDoc.info page][rubyd
 
 The Rambling Trie has been tested with the following Ruby versions:
 
+* 3.4.x
 * 3.3.x
 * 3.2.x
 * 3.1.x

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ want edge documentation, you can go the [GitHub project RubyDoc.info page][rubyd
 
 The Rambling Trie has been tested with the following Ruby versions:
 
+* 4.0.x
 * 3.4.x
 * 3.3.x
 * 3.2.x

--- a/rambling-trie.gemspec
+++ b/rambling-trie.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |gem|
   gem.license = 'MIT'
   gem.version = Rambling::Trie::VERSION
   gem.platform = Gem::Platform::RUBY
-  gem.required_ruby_version = '>= 3.1', '< 4'
+  gem.required_ruby_version = '>= 3.2', '< 4'
 end

--- a/rambling-trie.gemspec
+++ b/rambling-trie.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |gem|
   gem.license = 'MIT'
   gem.version = Rambling::Trie::VERSION
   gem.platform = Gem::Platform::RUBY
-  gem.required_ruby_version = '>= 3.2', '< 4'
+  gem.required_ruby_version = '>= 3.2', '< 5'
 end


### PR DESCRIPTION
`3.1.x` has been EOL'd, so:
- Bump min versions from `3.1.0` to `3.2.0`
- Update README and CHANGELOG