### PR TITLE
Fix `Compressor` silently dropping `false` node values during compression

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -36,6 +36,8 @@ detectors:
   NilCheck:
     exclude:
       - 'Rambling::Trie::Configuration::ProviderCollection#contains?' # necessary for steep type check
+      - 'Rambling::Trie::Compressor#compress_children_and_copy' # necessary for steep type check
+      - 'Rambling::Trie::Compressor#merge' # necessary for steep type check
 
   TooManyMethods:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Fix `Readers::PlainText` yielding `nil` for last word when file has no trailing newline ([#91][github_pull_91])
   by [@gonzedge][github_user_gonzedge]
+- Fix `Compressor` silently dropping `false` node values during compression ([#92][github_pull_92])
+  by [@gonzedge][github_user_gonzedge]
+  - Use `value.nil?` instead of `if value` guard
+  - Add `_Nilable` to `TValue` constraint across all RBS type signatures
 
 #### Minor
 
@@ -1310,6 +1314,7 @@ Most of these help with the gem's overall performance.
 [github_pull_88]: https://github.com/gonzedge/rambling-trie/pull/88
 [github_pull_90]: https://github.com/gonzedge/rambling-trie/pull/90
 [github_pull_91]: https://github.com/gonzedge/rambling-trie/pull/91
+[github_pull_92]: https://github.com/gonzedge/rambling-trie/pull/92
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/lib/rambling/trie/compressor.rb
+++ b/lib/rambling/trie/compressor.rb
@@ -37,7 +37,7 @@ module Rambling
         if other.terminal?
           compressed.terminal!
           value = other.value
-          compressed.value = value if value
+          compressed.value = value unless value.nil?
         end
         compressed
       end
@@ -48,7 +48,7 @@ module Rambling
         if node.terminal?
           compressed.terminal!
           value = node.value
-          compressed.value = value if value
+          compressed.value = value unless value.nil?
         end
         compressed
       end

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -2,24 +2,24 @@ module Rambling
   module Trie
     VERSION: String
 
-    def self.create: [TValue < _Inspect] (?String?, ?Readers::Reader?) ?{ (Container[TValue]) -> void } -> Container[TValue]
+    def self.create: [TValue < _Inspect & _Nilable] (?String?, ?Readers::Reader?) ?{ (Container[TValue]) -> void } -> Container[TValue]
 
-    def self.load: [TValue < _Inspect] (String, ?Serializers::Serializer[Nodes::Node[TValue]]?) ?{ (Container[TValue]) -> void } -> Container[TValue]
+    def self.load: [TValue < _Inspect & _Nilable] (String, ?Serializers::Serializer[Nodes::Node[TValue]]?) ?{ (Container[TValue]) -> void } -> Container[TValue]
 
-    def self.dump: [TValue < _Inspect] (Container[TValue], String, ?Serializers::Serializer[Nodes::Node[TValue]]?) -> void
+    def self.dump: [TValue < _Inspect & _Nilable] (Container[TValue], String, ?Serializers::Serializer[Nodes::Node[TValue]]?) -> void
 
-    def self.config: [TValue < _Inspect] ?{ (Configuration::Properties[TValue]) -> void } -> Configuration::Properties[TValue]
+    def self.config: [TValue < _Inspect & _Nilable] ?{ (Configuration::Properties[TValue]) -> void } -> Configuration::Properties[TValue]
 
     private
 
-    def self.properties: [TValue < _Inspect] -> Configuration::Properties[TValue]
+    def self.properties: [TValue < _Inspect & _Nilable] -> Configuration::Properties[TValue]
 
     def self.readers: -> Configuration::ProviderCollection[Readers::Reader]
 
-    def self.serializers: [TValue < _Inspect] -> Configuration::ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
+    def self.serializers: [TValue < _Inspect & _Nilable] -> Configuration::ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
 
-    def self.compressor: [TValue < _Inspect] -> Compressor[TValue]
+    def self.compressor: [TValue < _Inspect & _Nilable] -> Compressor[TValue]
 
-    def self.root_builder: [TValue < _Inspect] -> ^() -> Nodes::Node[TValue]
+    def self.root_builder: [TValue < _Inspect & _Nilable] -> ^() -> Nodes::Node[TValue]
   end
 end

--- a/sig/lib/rambling/trie/comparable.rbs
+++ b/sig/lib/rambling/trie/comparable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Comparable[TValue < _Inspect]
+    module Comparable[TValue < _Inspect & _Nilable]
       def ==: (Nodes::Node[TValue]) -> bool
 
       private

--- a/sig/lib/rambling/trie/compressible.rbs
+++ b/sig/lib/rambling/trie/compressible.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Compressible[TValue < _Inspect]
+    module Compressible[TValue < _Inspect & _Nilable]
       def compressible?: -> bool
 
       private

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    class Compressor[TValue < _Inspect]
+    class Compressor[TValue < _Inspect & _Nilable]
       def compress: (Nodes::Node[TValue]?) -> Nodes::Compressed[TValue]?
 
       private

--- a/sig/lib/rambling/trie/configuration/properties.rbs
+++ b/sig/lib/rambling/trie/configuration/properties.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Configuration
-      class Properties[TValue < _Inspect]
+      class Properties[TValue < _Inspect & _Nilable]
         attr_reader readers: ProviderCollection[Readers::Reader]
         attr_reader serializers: ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
         attr_accessor compressor: Compressor[TValue]

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    class Container[TValue < _Inspect]
+    class Container[TValue < _Inspect & _Nilable]
       include ::Enumerable[String]
 
       @compressor: Compressor[TValue]

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Enumerable[TValue < _Inspect]
+    module Enumerable[TValue < _Inspect & _Nilable]
       include ::Enumerable[String]
 
       EMPTY_ENUMERATOR: Enumerator[String, void]

--- a/sig/lib/rambling/trie/inspectable.rbs
+++ b/sig/lib/rambling/trie/inspectable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Inspectable[TValue < _Inspect]
+    module Inspectable[TValue < _Inspect & _Nilable]
 
       def inspect: -> String
 

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Compressed[TValue < _Inspect] < Node[TValue]
+      class Compressed[TValue < _Inspect & _Nilable] < Node[TValue]
         def initialize: (?Symbol?, ?Node[TValue]?, ?Hash[Symbol, Node[TValue]]) -> void
 
         def add: (Array[Symbol], ?TValue) -> Node[TValue]

--- a/sig/lib/rambling/trie/nodes/missing.rbs
+++ b/sig/lib/rambling/trie/nodes/missing.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Missing[TValue < _Inspect] < Node[TValue]
+      class Missing[TValue < _Inspect & _Nilable] < Node[TValue]
         def initialize: -> void
       end
     end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Node[TValue < _Inspect]
+      class Node[TValue < _Inspect & _Nilable]
         include Compressible[TValue]
         include Enumerable[TValue]
         include Comparable[TValue]

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Raw[TValue < _Inspect] < Node[TValue]
+      class Raw[TValue < _Inspect & _Nilable] < Node[TValue]
         def add: (Array[Symbol], ?TValue?) -> Node[TValue]
 
         def compressed?: -> bool

--- a/sig/lib/rambling/trie/serializers/marshal.rbs
+++ b/sig/lib/rambling/trie/serializers/marshal.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Marshal[TValue < _Inspect] < Serializer[Nodes::Node[TValue]]
+      class Marshal[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @serializer: Serializer[String]
 
         private

--- a/sig/lib/rambling/trie/serializers/yaml.rbs
+++ b/sig/lib/rambling/trie/serializers/yaml.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Yaml[TValue < _Inspect] < Serializer[Nodes::Node[TValue]]
+      class Yaml[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @serializer: Serializer[String]
 
         private

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Zip[TValue < _Inspect] < Serializer[Nodes::Node[TValue]]
+      class Zip[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @properties: Configuration::Properties[TValue]
 
         def initialize: (Configuration::Properties[TValue]) -> void

--- a/sig/lib/rambling/trie/stringifyable.rbs
+++ b/sig/lib/rambling/trie/stringifyable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Stringifyable[TValue < _Inspect]
+    module Stringifyable[TValue < _Inspect & _Nilable]
       def as_word: -> String
 
       def to_s: -> String

--- a/spec/lib/rambling/trie/compressor_spec.rb
+++ b/spec/lib/rambling/trie/compressor_spec.rb
@@ -129,6 +129,27 @@ describe Rambling::Trie::Compressor do
         expect(compressed[:w][:s].value).to eq 1
       end
       # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+
+      it 'preserves false as a value in compressed terminal nodes' do
+        add_words node, %w(word), [false]
+        compressed = compressor.compress node
+
+        expect(compressed[:w].value).to be false
+      end
+
+      it 'preserves 0 as a value in compressed terminal nodes' do
+        add_words node, %w(word), [0]
+        compressed = compressor.compress node
+
+        expect(compressed[:w].value).to eq 0
+      end
+
+      it 'preserves empty string as a value in compressed terminal nodes' do
+        add_words node, %w(word), ['']
+        compressed = compressor.compress node
+
+        expect(compressed[:w].value).to eq ''
+      end
     end
   end
 end


### PR DESCRIPTION
_Deals with issue no. 2 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Currently, `Compressor#merge` and `Compressor#compress_children_and_copy` skip over any falsy `node.value`. This works fine for other properties to save space as they are guaranteed to be a boolean type, but is a problem for `node.value` because an explicit `false` value gets lost and can only be recovered via `!!value`, which is boolean-specific logic.

This PR prevents `false` values from being dropped by using `value.nil?` instead of `if value` guard.

---

Also, some necessary type updates:
- Make `TValue` a `_Nilable`
- Exclude methods from reek for typecheck