### PR TITLE
Replace shared `EMPTY_ENUMERATOR` constant with `empty_enum` method

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -66,3 +66,5 @@ detectors:
       # Rambling::Trie::Serializers::File are intentionally using ::File methods
       - 'Rambling::Trie::Serializers::File#dump'
       - 'Rambling::Trie::Serializers::File#load'
+      # Rambling::Trie::Enumerable is very utilitarian anyway
+      - 'Rambling::Trie::Enumerable#empty_enum'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 #### Minor
 
+- Replace shared `Enumerable::EMPTY_ENUMERATOR` constant with `#empty_enum` method ([#93][github_pull_93])
+  by [@gonzedge][github_user_gonzedge]
+  - Fixes `Ruby::UnannotatedEmptyCollection` steep error on empty array literal
+  - Extract `Nodes::Compressed#match_child_prefix` to satisfy `Metrics/AbcSize`
 - Add `rbs-collection` for gem dependency signatures ([#90][github_pull_90]) by [@gonzedge][github_user_gonzedge]
   - Add `rbs_collection.yaml` with gem type definitions
   - Update `Steepfile` to use rbs collection
@@ -1315,6 +1319,7 @@ Most of these help with the gem's overall performance.
 [github_pull_90]: https://github.com/gonzedge/rambling-trie/pull/90
 [github_pull_91]: https://github.com/gonzedge/rambling-trie/pull/91
 [github_pull_92]: https://github.com/gonzedge/rambling-trie/pull/92
+[github_pull_93]: https://github.com/gonzedge/rambling-trie/pull/93
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/lib/rambling/trie/enumerable.rb
+++ b/lib/rambling/trie/enumerable.rb
@@ -6,10 +6,6 @@ module Rambling
     module Enumerable
       include ::Enumerable
 
-      # Empty enumerator constant for early each exits.
-      EMPTY_ENUMERATOR = [] # : Array[String]
-                         .to_enum :each
-
       # Returns number of words contained in the trie
       # @see https://ruby-doc.org/3.3.0/Enumerable.html#method-i-count Enumerable#count
       alias_method :size, :count
@@ -25,6 +21,14 @@ module Rambling
         children_tree.each_value { |child| child.each { |word| yield word } }
 
         self
+      end
+
+      # Returns a new empty enumerator for early-exit returns.
+      # A method rather than a constant to prevent shared mutable state.
+      def empty_enum
+        # @type var empty_array: Array[String]
+        empty_array = []
+        empty_array.each
       end
     end
   end

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -89,15 +89,15 @@ module Rambling
         def children_match_prefix chars
           return enum_for :children_match_prefix, chars unless block_given?
 
-          return EMPTY_ENUMERATOR if chars.empty?
+          return empty_enum if chars.empty?
 
           child = children_tree[(chars.first || raise).to_sym]
-          return EMPTY_ENUMERATOR unless child
+          return empty_enum unless child
 
           child_letter = child.letter.to_s
           letter = (chars.shift(child_letter.size) || raise).join
 
-          return EMPTY_ENUMERATOR unless child_letter == letter
+          return empty_enum unless child_letter == letter
 
           child.match_prefix(chars) { |word| yield word }
         end

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -94,6 +94,10 @@ module Rambling
           child = children_tree[(chars.first || raise).to_sym]
           return empty_enum unless child
 
+          match_child_prefix(child, chars) { |word| yield word }
+        end
+
+        def match_child_prefix child, chars
           child_letter = child.letter.to_s
           letter = (chars.shift(child_letter.size) || raise).join
 

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -70,10 +70,10 @@ module Rambling
         def children_match_prefix chars
           return enum_for :children_match_prefix, chars unless block_given?
 
-          return EMPTY_ENUMERATOR if chars.empty?
+          return empty_enum if chars.empty?
 
           child = children_tree[(chars.shift || raise).to_sym]
-          return EMPTY_ENUMERATOR unless child
+          return empty_enum unless child
 
           child.match_prefix(chars) { |word| yield word }
         end

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -3,8 +3,6 @@ module Rambling
     module Enumerable[TValue < _Inspect & _Nilable]
       include ::Enumerable[String]
 
-      EMPTY_ENUMERATOR: Enumerator[String, void]
-
       alias size count
 
       def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable[TValue])
@@ -14,6 +12,8 @@ module Rambling
       # abstract methods
 
       def as_word: -> String
+
+      def empty_enum: -> Enumerator[String, void]
 
       def terminal?: -> bool
 

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -14,6 +14,8 @@ module Rambling
 
         def children_match_prefix: (Array[String]) { (String) -> void } -> Enumerator[String, void]
 
+        def match_child_prefix: (Node[TValue], Array[String]) { (String) -> void } -> Enumerator[String, void]
+
         def partial_word_chars?: (Array[String]) -> bool
 
         def word_chars?: (Array[String]) -> bool

--- a/spec/lib/rambling/trie/enumerable_spec.rb
+++ b/spec/lib/rambling/trie/enumerable_spec.rb
@@ -49,6 +49,17 @@ module Rambling
       it 'includes #to_a from the core Enumerable module' do
         expect(node.to_a).to match_array words
       end
+
+      describe '#empty_enumerator' do
+        it 'returns independent objects for each empty match result' do
+          # rubocop:disable Lint/EmptyBlock
+          first  = node.empty_enum {}
+          second = node.empty_enum {}
+          # rubocop:enable Lint/EmptyBlock
+
+          expect(first).not_to be second
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
_Deals with issue no. 3 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Not a common use case, but if two separate execution contexts could interfere with each other when calling `.next` all `.rewind` on the `EMPTY_ENUMERATOR`.

This PR fixes this by adding a new `Rambling::Trie::Enumerable#empty_enum` that creates a new array every time, when an empty enumerator is needed. Also:

- Deal with rbs/steep `Ruby::UnannotatedEmptyCollection` in `#empty_enum`
- Extract `Nodes::Compressed#match_child_prefix` to deal with rubocop `Metrics/AbcSize` getting triggered all of a sudden
-  Exclude `Rambling::Trie::Enumerable#empty_enum` from reek `UtilityFunction` check