### PR TITLE
Take `value` into account during `Comparable#==`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,22 @@
   by [@gonzedge][github_user_gonzedge]
   - Use `value.nil?` instead of `if value` guard
   - Add `_Nilable` to `TValue` constraint across all RBS type signatures
+- Take `value` into account during `Comparable#==` ([#94][github_pull_94])
+  by [@gonzedge][github_user_gonzedge]
+  - Add `value` comparison to `Comparable#==`
+  - Add `BasicObject` to `TValue` constraint across all RBS type signatures to allow equality checks
 
 #### Minor
 
-- Replace shared `Enumerable::EMPTY_ENUMERATOR` constant with `#empty_enum` method ([#93][github_pull_93])
-  by [@gonzedge][github_user_gonzedge]
-  - Fixes `Ruby::UnannotatedEmptyCollection` steep error on empty array literal
-  - Extract `Nodes::Compressed#match_child_prefix` to satisfy `Metrics/AbcSize`
 - Add `rbs-collection` for gem dependency signatures ([#90][github_pull_90]) by [@gonzedge][github_user_gonzedge]
   - Add `rbs_collection.yaml` with gem type definitions
   - Update `Steepfile` to use rbs collection
   - Add `rbs collection update` step to lint CI job
   - Remove now-unnecessary `#noinspection` comments
+- Replace shared `Enumerable::EMPTY_ENUMERATOR` constant with `#empty_enum` method ([#93][github_pull_93])
+  by [@gonzedge][github_user_gonzedge]
+  - Fixes `Ruby::UnannotatedEmptyCollection` steep error on empty array literal
+  - Extract `Nodes::Compressed#match_child_prefix` to satisfy `Metrics/AbcSize`
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1320,6 +1324,7 @@ Most of these help with the gem's overall performance.
 [github_pull_91]: https://github.com/gonzedge/rambling-trie/pull/91
 [github_pull_92]: https://github.com/gonzedge/rambling-trie/pull/92
 [github_pull_93]: https://github.com/gonzedge/rambling-trie/pull/93
+[github_pull_94]: https://github.com/gonzedge/rambling-trie/pull/94
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/lib/rambling/trie/comparable.rb
+++ b/lib/rambling/trie/comparable.rb
@@ -11,6 +11,7 @@ module Rambling
       def == other
         letter == other.letter &&
           terminal? == other.terminal? &&
+          value == other.value &&
           children_tree == other.children_tree
       end
     end

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -2,24 +2,24 @@ module Rambling
   module Trie
     VERSION: String
 
-    def self.create: [TValue < _Inspect & _Nilable] (?String?, ?Readers::Reader?) ?{ (Container[TValue]) -> void } -> Container[TValue]
+    def self.create: [TValue < BasicObject & _Inspect & _Nilable] (?String?, ?Readers::Reader?) ?{ (Container[TValue]) -> void } -> Container[TValue]
 
-    def self.load: [TValue < _Inspect & _Nilable] (String, ?Serializers::Serializer[Nodes::Node[TValue]]?) ?{ (Container[TValue]) -> void } -> Container[TValue]
+    def self.load: [TValue < BasicObject & _Inspect & _Nilable] (String, ?Serializers::Serializer[Nodes::Node[TValue]]?) ?{ (Container[TValue]) -> void } -> Container[TValue]
 
-    def self.dump: [TValue < _Inspect & _Nilable] (Container[TValue], String, ?Serializers::Serializer[Nodes::Node[TValue]]?) -> void
+    def self.dump: [TValue < BasicObject & _Inspect & _Nilable] (Container[TValue], String, ?Serializers::Serializer[Nodes::Node[TValue]]?) -> void
 
-    def self.config: [TValue < _Inspect & _Nilable] ?{ (Configuration::Properties[TValue]) -> void } -> Configuration::Properties[TValue]
+    def self.config: [TValue < BasicObject & _Inspect & _Nilable] ?{ (Configuration::Properties[TValue]) -> void } -> Configuration::Properties[TValue]
 
     private
 
-    def self.properties: [TValue < _Inspect & _Nilable] -> Configuration::Properties[TValue]
+    def self.properties: [TValue < BasicObject & _Inspect & _Nilable] -> Configuration::Properties[TValue]
 
     def self.readers: -> Configuration::ProviderCollection[Readers::Reader]
 
-    def self.serializers: [TValue < _Inspect & _Nilable] -> Configuration::ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
+    def self.serializers: [TValue < BasicObject & _Inspect & _Nilable] -> Configuration::ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
 
-    def self.compressor: [TValue < _Inspect & _Nilable] -> Compressor[TValue]
+    def self.compressor: [TValue < BasicObject & _Inspect & _Nilable] -> Compressor[TValue]
 
-    def self.root_builder: [TValue < _Inspect & _Nilable] -> ^() -> Nodes::Node[TValue]
+    def self.root_builder: [TValue < BasicObject & _Inspect & _Nilable] -> ^() -> Nodes::Node[TValue]
   end
 end

--- a/sig/lib/rambling/trie/comparable.rbs
+++ b/sig/lib/rambling/trie/comparable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Comparable[TValue < _Inspect & _Nilable]
+    module Comparable[TValue < BasicObject & _Inspect & _Nilable]
       def ==: (Nodes::Node[TValue]) -> bool
 
       private
@@ -8,6 +8,8 @@ module Rambling
       # abstract methods
 
       def letter: -> Symbol
+
+      def value: -> TValue
 
       def terminal?: -> bool
 

--- a/sig/lib/rambling/trie/compressible.rbs
+++ b/sig/lib/rambling/trie/compressible.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Compressible[TValue < _Inspect & _Nilable]
+    module Compressible[TValue < BasicObject & _Inspect & _Nilable]
       def compressible?: -> bool
 
       private

--- a/sig/lib/rambling/trie/compressor.rbs
+++ b/sig/lib/rambling/trie/compressor.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    class Compressor[TValue < _Inspect & _Nilable]
+    class Compressor[TValue < BasicObject & _Inspect & _Nilable]
       def compress: (Nodes::Node[TValue]?) -> Nodes::Compressed[TValue]?
 
       private

--- a/sig/lib/rambling/trie/configuration/properties.rbs
+++ b/sig/lib/rambling/trie/configuration/properties.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Configuration
-      class Properties[TValue < _Inspect & _Nilable]
+      class Properties[TValue < BasicObject & _Inspect & _Nilable]
         attr_reader readers: ProviderCollection[Readers::Reader]
         attr_reader serializers: ProviderCollection[Serializers::Serializer[Nodes::Node[TValue]]]
         attr_accessor compressor: Compressor[TValue]

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    class Container[TValue < _Inspect & _Nilable]
+    class Container[TValue < BasicObject & _Inspect & _Nilable]
       include ::Enumerable[String]
 
       @compressor: Compressor[TValue]

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Enumerable[TValue < _Inspect & _Nilable]
+    module Enumerable[TValue < BasicObject & _Inspect & _Nilable]
       include ::Enumerable[String]
 
       alias size count

--- a/sig/lib/rambling/trie/inspectable.rbs
+++ b/sig/lib/rambling/trie/inspectable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Inspectable[TValue < _Inspect & _Nilable]
+    module Inspectable[TValue < BasicObject & _Inspect & _Nilable]
 
       def inspect: -> String
 

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Compressed[TValue < _Inspect & _Nilable] < Node[TValue]
+      class Compressed[TValue < BasicObject & _Inspect & _Nilable] < Node[TValue]
         def initialize: (?Symbol?, ?Node[TValue]?, ?Hash[Symbol, Node[TValue]]) -> void
 
         def add: (Array[Symbol], ?TValue) -> Node[TValue]

--- a/sig/lib/rambling/trie/nodes/missing.rbs
+++ b/sig/lib/rambling/trie/nodes/missing.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Missing[TValue < _Inspect & _Nilable] < Node[TValue]
+      class Missing[TValue < BasicObject & _Inspect & _Nilable] < Node[TValue]
         def initialize: -> void
       end
     end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Node[TValue < _Inspect & _Nilable]
+      class Node[TValue < BasicObject & _Inspect & _Nilable]
         include Compressible[TValue]
         include Enumerable[TValue]
         include Comparable[TValue]

--- a/sig/lib/rambling/trie/nodes/raw.rbs
+++ b/sig/lib/rambling/trie/nodes/raw.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Nodes
-      class Raw[TValue < _Inspect & _Nilable] < Node[TValue]
+      class Raw[TValue < BasicObject & _Inspect & _Nilable] < Node[TValue]
         def add: (Array[Symbol], ?TValue?) -> Node[TValue]
 
         def compressed?: -> bool

--- a/sig/lib/rambling/trie/serializers/marshal.rbs
+++ b/sig/lib/rambling/trie/serializers/marshal.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Marshal[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
+      class Marshal[TValue < BasicObject & _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @serializer: Serializer[String]
 
         private

--- a/sig/lib/rambling/trie/serializers/yaml.rbs
+++ b/sig/lib/rambling/trie/serializers/yaml.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Yaml[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
+      class Yaml[TValue < BasicObject & _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @serializer: Serializer[String]
 
         private

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -1,7 +1,7 @@
 module Rambling
   module Trie
     module Serializers
-      class Zip[TValue < _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
+      class Zip[TValue < BasicObject & _Inspect & _Nilable] < Serializer[Nodes::Node[TValue]]
         @properties: Configuration::Properties[TValue]
 
         def initialize: (Configuration::Properties[TValue]) -> void

--- a/sig/lib/rambling/trie/stringifyable.rbs
+++ b/sig/lib/rambling/trie/stringifyable.rbs
@@ -1,6 +1,6 @@
 module Rambling
   module Trie
-    module Stringifyable[TValue < _Inspect & _Nilable]
+    module Stringifyable[TValue < BasicObject & _Inspect & _Nilable]
       def as_word: -> String
 
       def to_s: -> String

--- a/spec/lib/rambling/trie/comparable_spec.rb
+++ b/spec/lib/rambling/trie/comparable_spec.rb
@@ -83,5 +83,52 @@ describe Rambling::Trie::Comparable do
         expect(node_one).not_to eq node_two
       end
     end
+
+    context 'when nodes are otherwise identical but have different values' do
+      before do
+        node_one.letter = :a
+        node_one.terminal!
+        node_one.value = 1
+
+        node_two.letter = :a
+        node_two.terminal!
+        node_two.value = 2
+      end
+
+      it 'returns false' do
+        expect(node_one).not_to eq node_two
+      end
+    end
+
+    context 'when nodes are identical including the same value' do
+      before do
+        node_one.letter = :a
+        node_one.terminal!
+        node_one.value = :same
+
+        node_two.letter = :a
+        node_two.terminal!
+        node_two.value = :same
+      end
+
+      it 'returns true' do
+        expect(node_one).to eq node_two
+      end
+    end
+
+    context 'when nodes have the same structure but one has a value and the other does not' do
+      before do
+        node_one.letter = :a
+        node_one.terminal!
+        node_one.value = 42
+
+        node_two.letter = :a
+        node_two.terminal!
+      end
+
+      it 'returns false' do
+        expect(node_one).not_to eq node_two
+      end
+    end
   end
 end


### PR DESCRIPTION
_Deals with issue no. 4 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

After adding the ability to hold arbitrary values in #85 (released in `v2.6.0`), a few method definitions and comments are no longer quite accurate. One of those is `Rambling::Trie::Comparable#==`, which currently doesn't compare the `value`s when comparing nodes.

This PR fixes that by comparing `value == other.value` _before_ comparing `children_tree`s.

Also, make `TValue` be at least a `BasicObject` to get equality methods (`==`, `!=`, etc) and fix newly introduced rbs/steep issues.