### PR TITLE
Fix `Serializers::Zip#(load|dump)` leaking tmp files

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -32,6 +32,9 @@ detectors:
       - 'Rambling::Trie#create' # inner iteration goes through each word in given file
       - 'Rambling::Trie::Container#words_within_root' # inner iteration does a match of each prefix
       - 'Rambling::Trie::Enumerable#each' # inner iteration goes through each word in children_tree
+      # Rambling::Trie::Serializers::Zip nested iteration is for cleanup
+      - 'Rambling::Trie::Serializers::Zip#load'
+      - 'Rambling::Trie::Serializers::Zip#dump'
 
   NilCheck:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
   by [@gonzedge][github_user_gonzedge]
   - Use `value.nil?` instead of `if value` guard
   - Add `_Nilable` to `TValue` constraint across all RBS type signatures
-- Take `value` into account during `Comparable#==` ([#94][github_pull_94])
-  by [@gonzedge][github_user_gonzedge]
+- Take `value` into account during `Comparable#==` ([#94][github_pull_94]) by [@gonzedge][github_user_gonzedge]
   - Add `value` comparison to `Comparable#==`
   - Add `BasicObject` to `TValue` constraint across all RBS type signatures to allow equality checks
+- Fix `Serializers::Zip#(load|dump)` leaking tmp files ([#95][github_pull_95]) by [@gonzedge][github_user_gonzedge]
+  - Add common `Serializer::Zip#clean_up_tmp_files` method
+  - Use `(serializers.resolve(filename) || raise).<method>` trick to reduce method sizes
 
 #### Minor
 
@@ -1325,6 +1327,7 @@ Most of these help with the gem's overall performance.
 [github_pull_92]: https://github.com/gonzedge/rambling-trie/pull/92
 [github_pull_93]: https://github.com/gonzedge/rambling-trie/pull/93
 [github_pull_94]: https://github.com/gonzedge/rambling-trie/pull/94
+[github_pull_95]: https://github.com/gonzedge/rambling-trie/pull/95
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -24,14 +24,14 @@ module Rambling
         def load filepath
           require 'zip'
 
-          with_cleanup_paths do |cleanup_paths|
+          clean_up_tmp_files do |tmp_paths|
             ::Zip::File.open filepath do |zip|
               entry = zip.entries.first
               raise unless entry
 
               entry_name = entry.name
               entry_path = path entry_name
-              cleanup_paths << entry_path
+              tmp_paths << entry_path
 
               entry.extract ::File.basename(entry_path), destination_directory: tmp_path
 
@@ -49,12 +49,12 @@ module Rambling
         def dump contents, filepath
           require 'zip'
 
-          with_cleanup_paths do |cleanup_paths|
+          clean_up_tmp_files do |tmp_paths|
             ::Zip::File.open filepath, create: true do |zip|
               filename = ::File.basename filepath, '.zip'
 
               entry_path = path filename
-              cleanup_paths << entry_path
+              tmp_paths << entry_path
 
               (serializers.resolve(filename) || raise).dump contents, entry_path
               zip.add filename, entry_path
@@ -81,13 +81,13 @@ module Rambling
           ::File.join tmp_path, "#{SecureRandom.uuid}-#{filename}"
         end
 
-        def with_cleanup_paths
-          # @type var cleanup_paths: Array[String]
-          cleanup_paths = []
+        def clean_up_tmp_files
+          # @type var tmp_paths: Array[String]
+          tmp_paths = []
           begin
-            yield cleanup_paths
+            yield tmp_paths
           ensure
-            cleanup_paths.each { |path| ::FileUtils.rm_f path }
+            tmp_paths.each { |path| ::FileUtils.rm_f path }
           end
         end
       end

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -24,6 +24,8 @@ module Rambling
         def load filepath
           require 'zip'
 
+          entry_path = nil
+
           ::Zip::File.open filepath do |zip|
             entry = zip.entries.first
             raise unless entry
@@ -36,6 +38,8 @@ module Rambling
             raise unless serializer
 
             serializer.load entry_path
+          ensure
+            ::File.delete entry_path if entry_path && ::File.exist?(entry_path)
           end
         end
 
@@ -48,17 +52,23 @@ module Rambling
         def dump contents, filepath
           require 'zip'
 
-          ::Zip::File.open filepath, create: true do |zip|
-            filename = ::File.basename filepath, '.zip'
+          entry_path = nil
 
-            entry_path = path filename
-            serializer = serializers.resolve filename
+          begin
+            ::Zip::File.open filepath, create: true do |zip|
+              filename = ::File.basename filepath, '.zip'
 
-            raise unless serializer
+              entry_path = path filename
+              serializer = serializers.resolve filename
 
-            serializer.dump contents, entry_path
+              raise unless serializer
 
-            zip.add filename, entry_path
+              serializer.dump contents, entry_path
+
+              zip.add filename, entry_path
+            end
+          ensure
+            ::File.delete entry_path if entry_path && ::File.exist?(entry_path)
           end
 
           ::File.size filepath

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -24,7 +24,8 @@ module Rambling
         def load filepath
           require 'zip'
 
-          entry_path = nil
+          # @type var cleanup_paths: Array[String]
+          cleanup_paths = []
 
           ::Zip::File.open filepath do |zip|
             entry = zip.entries.first
@@ -32,6 +33,8 @@ module Rambling
 
             entry_name = entry.name
             entry_path = path entry_name
+            cleanup_paths << entry_path
+
             entry.extract ::File.basename(entry_path), destination_directory: tmp_path
 
             serializer = serializers.resolve entry_name
@@ -39,7 +42,7 @@ module Rambling
 
             serializer.load entry_path
           ensure
-            ::File.delete entry_path if entry_path && ::File.exist?(entry_path)
+            cleanup_paths.each { |path| ::FileUtils.rm_f path }
           end
         end
 
@@ -52,13 +55,16 @@ module Rambling
         def dump contents, filepath
           require 'zip'
 
-          entry_path = nil
+          # @type var cleanup_paths: Array[String]
+          cleanup_paths = []
 
           begin
             ::Zip::File.open filepath, create: true do |zip|
               filename = ::File.basename filepath, '.zip'
 
               entry_path = path filename
+              cleanup_paths << entry_path
+
               serializer = serializers.resolve filename
 
               raise unless serializer
@@ -68,7 +74,7 @@ module Rambling
               zip.add filename, entry_path
             end
           ensure
-            ::File.delete entry_path if entry_path && ::File.exist?(entry_path)
+            cleanup_paths.each { |path| ::FileUtils.rm_f path }
           end
 
           ::File.size filepath

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -24,21 +24,19 @@ module Rambling
         def load filepath
           require 'zip'
 
-          # @type var cleanup_paths: Array[String]
-          cleanup_paths = []
+          with_cleanup_paths do |cleanup_paths|
+            ::Zip::File.open filepath do |zip|
+              entry = zip.entries.first
+              raise unless entry
 
-          ::Zip::File.open filepath do |zip|
-            entry = zip.entries.first
-            raise unless entry
+              entry_name = entry.name
+              entry_path = path entry_name
+              cleanup_paths << entry_path
 
-            entry_name = entry.name
-            entry_path = path entry_name
-            cleanup_paths << entry_path
+              entry.extract ::File.basename(entry_path), destination_directory: tmp_path
 
-            entry.extract ::File.basename(entry_path), destination_directory: tmp_path
-            (serializers.resolve(entry_name) || raise).load entry_path
-          ensure
-            cleanup_paths.each { |path| ::FileUtils.rm_f path }
+              (serializers.resolve(entry_name) || raise).load entry_path
+            end
           end
         end
 
@@ -51,10 +49,7 @@ module Rambling
         def dump contents, filepath
           require 'zip'
 
-          # @type var cleanup_paths: Array[String]
-          cleanup_paths = []
-
-          begin
+          with_cleanup_paths do |cleanup_paths|
             ::Zip::File.open filepath, create: true do |zip|
               filename = ::File.basename filepath, '.zip'
 
@@ -64,8 +59,6 @@ module Rambling
               (serializers.resolve(filename) || raise).dump contents, entry_path
               zip.add filename, entry_path
             end
-          ensure
-            cleanup_paths.each { |path| ::FileUtils.rm_f path }
           end
 
           ::File.size filepath
@@ -86,6 +79,16 @@ module Rambling
         def path filename
           require 'securerandom'
           ::File.join tmp_path, "#{SecureRandom.uuid}-#{filename}"
+        end
+
+        def with_cleanup_paths
+          # @type var cleanup_paths: Array[String]
+          cleanup_paths = []
+          begin
+            yield cleanup_paths
+          ensure
+            cleanup_paths.each { |path| ::FileUtils.rm_f path }
+          end
         end
       end
     end

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -36,11 +36,7 @@ module Rambling
             cleanup_paths << entry_path
 
             entry.extract ::File.basename(entry_path), destination_directory: tmp_path
-
-            serializer = serializers.resolve entry_name
-            raise unless serializer
-
-            serializer.load entry_path
+            (serializers.resolve(entry_name) || raise).load entry_path
           ensure
             cleanup_paths.each { |path| ::FileUtils.rm_f path }
           end
@@ -65,12 +61,7 @@ module Rambling
               entry_path = path filename
               cleanup_paths << entry_path
 
-              serializer = serializers.resolve filename
-
-              raise unless serializer
-
-              serializer.dump contents, entry_path
-
+              (serializers.resolve(filename) || raise).dump contents, entry_path
               zip.add filename, entry_path
             end
           ensure

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -16,7 +16,7 @@ module Rambling
 
         def path: (String) -> String
 
-        def with_cleanup_paths: [T] { (Array[String]) -> T } -> T
+        def clean_up_tmp_files: [T] { (Array[String]) -> T } -> T
       end
     end
   end

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -15,6 +15,8 @@ module Rambling
         def tmp_path: -> String
 
         def path: (String) -> String
+
+        def with_cleanup_paths: [T] { (Array[String]) -> T } -> T
       end
     end
   end

--- a/spec/lib/rambling/trie/serializers/zip_spec.rb
+++ b/spec/lib/rambling/trie/serializers/zip_spec.rb
@@ -24,6 +24,45 @@ describe Rambling::Trie::Serializers::Zip do
     end
   end
 
+  describe 'zip-only behavior' do
+    let(:properties) { Rambling::Trie::Configuration::Properties.new }
+    let(:serializer) { described_class.new properties }
+    let(:tmp_path) { File.join SPEC_ROOT, 'tmp' }
+    let(:trie) { Rambling::Trie.create }
+    let(:zip_path) { File.join tmp_path, 'cleanup_test.marshal.zip' }
+    let(:cleanup_test_glob) { Dir.glob File.join(tmp_path, '*cleanup_test*') }
+
+    before do
+      properties.tmp_path = tmp_path
+      trie.concat %w(test cleanup words)
+      FileUtils.rm_f cleanup_test_glob
+    end
+
+    after do
+      FileUtils.rm_f zip_path
+      FileUtils.rm_f cleanup_test_glob
+    end
+
+    describe '#dump' do
+      it 'removes the tmp file' do
+        serializer.dump trie.root, zip_path
+
+        leftover_files = Dir.glob(File.join(tmp_path, '*-cleanup_test.marshal'))
+        expect(leftover_files).to be_empty
+      end
+    end
+
+    describe '#load' do
+      it 'removes the tmp file after #load' do
+        serializer.dump trie.root, zip_path
+        serializer.load zip_path
+
+        leftover_files = Dir.glob(File.join(tmp_path, '*-cleanup_test.marshal'))
+        expect(leftover_files).to be_empty
+      end
+    end
+  end
+
   def zip content
     cursor = Zip::OutputStream.write_buffer do |io|
       io.put_next_entry filename


### PR DESCRIPTION
_Deals with issue no. 5 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Currently, using `.zip` format actually creates a whole tmp files that are never cleaned up. This is my `spec/tmp` directory right now 😅:

```shell
ls spec/tmp | grep 'trie-root' | wc -l
# => 24458
ls spec/tmp | grep 'trie-root' | shuf -n 10
# => 7b2dad5d-7232-4505-a16b-4aa781fbc6ae-trie-root.file
# => a91a2b5b-c8c7-42bd-8bff-a008a616487c-trie-root.marshal
# => 8e50920f-604d-4e2b-abd2-5185adf65111-trie-root.yml
# => 9d604330-acef-4534-8f80-fd27c7b6a055-trie-root.yaml
# => 33e4fbae-6d24-4516-b49c-5297c39fbcde-trie-root.file
# => a245758f-166d-4401-8af1-83c37337c680-trie-root.marshal
# => 0c584959-1ab4-4c14-adee-105f81693b13-trie-root.file
# => 098c290e-a10f-448c-a31d-3e15e2990bd3-trie-root.yaml
# => e23fa379-4f4e-4a88-92bb-56162c6da558-trie-root.yml
# => fb5068d1-bce2-4bfb-9b27-682d618f40d6-trie-root.marshal
```

Yes, you read that right: 24K+ files accumulated over the years, all of them of the form `<uuid>-trie-root.<format>` 😞 - hopefully this hasn't caused any disk-space issues out there 😬 

This PR prevents that from being the case going forward by adding a new `Serializers::Zip#clean_up_tmp_files` that captures all tmp files and then iterates through to `FileUtils.rm_f`, then using this new method in both `Serializers::Zip#load` and `Serializers::Zip#dump`.

---

Also:
- Use `(serializers.resolve(filename) || raise).<method>` trick to reduce size of both `Serializers::Zip#load` and `Serializers::Zip#dump`, and make reek's `TooManyStatements` check happy
- Exclude `Rambling::Trie::Serializers::Zip#load` and `Rambling::Trie::Serializers::Zip#dump` from `NestedIterators` reek check, as they are now necessary (technically it's not nested iterators but nested blocks for this case anyway)