### PR TITLE
Raise `ArgumentError` in `Container#concat` on words/values size mismatch

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake rubocop
       - name: Run yardoc
-        run: bundle exec rake yard
+        run: >
+          bundle exec rake yard | tee yarddoc.log
+          cat yarddoc.log | grep '100.00% documented'
   spec:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake rubocop
       - name: Run yardoc
-        run: bundle exec rake yard | grep '100.00% documented'
+        run: bundle exec rake yard
   spec:
     runs-on: ubuntu-latest
     strategy:

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---markup=markdown --exclude lib/rambling/trie/tasks/
+--verbose --debug --markup=markdown --exclude lib/rambling/trie/tasks/ --exclude sig/lib/nilable.rbs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   by [@gonzedge][github_user_gonzedge]
   - Fixes `Ruby::UnannotatedEmptyCollection` steep error on empty array literal
   - Extract `Nodes::Compressed#match_child_prefix` to satisfy `Metrics/AbcSize`
+- Raise `ArgumentError` in `Container#concat` on words/values size mismatch ([#96][github_pull_96])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1328,6 +1330,7 @@ Most of these help with the gem's overall performance.
 [github_pull_93]: https://github.com/gonzedge/rambling-trie/pull/93
 [github_pull_94]: https://github.com/gonzedge/rambling-trie/pull/94
 [github_pull_95]: https://github.com/gonzedge/rambling-trie/pull/95
+[github_pull_96]: https://github.com/gonzedge/rambling-trie/pull/96
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,6 @@ RSpec::Core::RakeTask.new :spec
 Reek::Rake::Task.new :reek
 RuboCop::RakeTask.new :rubocop
 Steep::RakeTask.new :steep
-YARD::Rake::YardocTask.new :yard do |t|
-  t.options = %w(--verbose --debug)
-end
+YARD::Rake::YardocTask.new :yard
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,8 @@ RSpec::Core::RakeTask.new :spec
 Reek::Rake::Task.new :reek
 RuboCop::RakeTask.new :rubocop
 Steep::RakeTask.new :steep
-YARD::Rake::YardocTask.new :yard
+YARD::Rake::YardocTask.new :yard do |t|
+  t.options = %w(--verbose --debug)
+end
 
 task default: :spec

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -14,7 +14,7 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 | [x]  | 4  | **Critical** | `comparable.rb:11`               | `==` ignores the `value` attribute                                                      |
 | [x]  | 5  | **Critical** | `serializers/zip.rb:33,59`       | Temp files never cleaned up — resource leak                                             |
 | [ ]  | 6  | **High**     | `nodes/raw.rb:34`                | `add` mutates the caller's array                                                        |
-| [ ]  | 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
+| [x]  | 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
 | [ ]  | 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
 | [ ]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
 | [ ]  | 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -6,38 +6,38 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 
 ## Summary Table
 
-| #  | Severity     | File                             | Issue                                                                                   |
-|----|--------------|----------------------------------|-----------------------------------------------------------------------------------------|
-| 1  | **Critical** | `readers/plain_text.rb:15`       | `chomp!` yields `nil` → crash on files without trailing newline                         |
-| 2  | **Critical** | `compressor.rb:39,50`            | Falsy `value` silently dropped during compression                                       |
-| 3  | **Critical** | `enumerable.rb:10`               | Shared mutable `EMPTY_ENUMERATOR` Enumerator                                            |
-| 4  | **Critical** | `comparable.rb:11`               | `==` ignores the `value` attribute                                                      |
-| 5  | **Critical** | `serializers/zip.rb:33,59`       | Temp files never cleaned up — resource leak                                             |
-| 6  | **High**     | `nodes/raw.rb:34`                | `add` mutates the caller's array                                                        |
-| 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
-| 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
-| 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
-| 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |
-| 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`             |
-| 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                      |
-| 13 | **Medium**   | `stringifyable.rb:22`            | `to_s` has O(depth²) string allocations                                                 |
-| 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick                              |
-| 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`                                   |
-| 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                                              |
-| 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations in `reversed_char_symbols` |
-| 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context                       |
-| 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections                            |
-| 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                                                |
-| 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent                                |
-| 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem                             |
-| 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                          |
-| 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree — REPL/logging hazard on large tries                |
-| 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                        |
-| 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                         |
-| 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                              |
-| 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                        |
-| 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack                               |
-| 30 | **Low**      | `container.rb:61`                | `compress` returns `self` when already compressed — inconsistent identity               |
+| Done | #  | Severity     | File                             | Issue                                                                                   |
+|------|----|--------------|----------------------------------|-----------------------------------------------------------------------------------------|
+| [x]  | 1  | **Critical** | `readers/plain_text.rb:15`       | `chomp!` yields `nil` → crash on files without trailing newline                         |
+| [x]  | 2  | **Critical** | `compressor.rb:39,50`            | Falsy `value` silently dropped during compression                                       |
+| [x]  | 3  | **Critical** | `enumerable.rb:10`               | Shared mutable `EMPTY_ENUMERATOR` Enumerator                                            |
+| [x]  | 4  | **Critical** | `comparable.rb:11`               | `==` ignores the `value` attribute                                                      |
+| [x]  | 5  | **Critical** | `serializers/zip.rb:33,59`       | Temp files never cleaned up — resource leak                                             |
+| [ ]  | 6  | **High**     | `nodes/raw.rb:34`                | `add` mutates the caller's array                                                        |
+| [ ]  | 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
+| [ ]  | 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
+| [ ]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
+| [ ]  | 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |
+| [ ]  | 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`             |
+| [ ]  | 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                      |
+| [ ]  | 13 | **Medium**   | `stringifyable.rb:22`            | `to_s` has O(depth²) string allocations                                                 |
+| [ ]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick                              |
+| [ ]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`                                   |
+| [ ]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                                              |
+| [ ]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations in `reversed_char_symbols` |
+| [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context                       |
+| [ ]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections                            |
+| [ ]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                                                |
+| [ ]  | 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent                                |
+| [ ]  | 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem                             |
+| [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                          |
+| [ ]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree — REPL/logging hazard on large tries                |
+| [ ]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                        |
+| [ ]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                         |
+| [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                              |
+| [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                        |
+| [ ]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack                               |
+| [ ]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` when already compressed — inconsistent identity               |
 
 ---
 

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -39,6 +39,13 @@ module Rambling
       # @see Nodes::Compressed#add
       def concat words, values = nil
         if values
+          words_size = words.size
+          values_size = values.size
+          unless words_size == values_size
+            raise ArgumentError,
+              "words and values must have the same size (words: #{words_size}, values: #{values_size})"
+          end
+
           words.each_with_index.map { |word, index| add(word, values[index]) }
         else
           words.map { |word| add word }

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -70,6 +70,16 @@ describe Rambling::Trie::Container do
       expect(root[:w][:o][:r][:d][:s].value).to eq 20
     end
     # rubocop:enable RSpec/MultipleExpectations
+
+    it 'raises ArgumentError when words and values have different lengths' do
+      expect { container.concat %w(one two three), [1, 2] }
+        .to raise_error ArgumentError, %r{words and values must have the same size}
+    end
+
+    it 'raises ArgumentError when values is longer than words' do
+      expect { container.concat %w(one), [1, 2, 3] }
+        .to raise_error ArgumentError, %r{words and values must have the same size}
+    end
   end
 
   describe '#compress' do


### PR DESCRIPTION
_Deals with issue no. 7 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Currently, we don't check if the provided `values` match the number of provided `words`, so when there are more `words` than `values`, the extra ones stay with `nil`, and when there are more `values` than `words`, a few `values` go unused.

This PR fixes that by adding a guard in `Container#concat` and raise an `ArgumentError` whenever their sizes don't match.

---

Also:
- Use verbose+debug output for `yarddoc`
- Exclude `sig/lib/nilable.rbs` from `yarddoc`, though not sure why started appearing there _now_
- Add checkboxes for code review doc, with checked issues 1 through 5
- Mark issue 7 as fixed