### PR TITLE
Correct `Container#size` docs and RBS signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - Extract `Nodes::Compressed#match_child_prefix` to satisfy `Metrics/AbcSize`
 - Raise `ArgumentError` in `Container#concat` on words/values size mismatch ([#96][github_pull_96])
   by [@gonzedge][github_user_gonzedge]
+- Correct `Container#size` docs and RBS signature ([#97][github_pull_97]) by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1331,6 +1332,7 @@ Most of these help with the gem's overall performance.
 [github_pull_94]: https://github.com/gonzedge/rambling-trie/pull/94
 [github_pull_95]: https://github.com/gonzedge/rambling-trie/pull/95
 [github_pull_96]: https://github.com/gonzedge/rambling-trie/pull/96
+[github_pull_97]: https://github.com/gonzedge/rambling-trie/pull/97
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -15,7 +15,7 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 | [x]  | 5  | **Critical** | `serializers/zip.rb:33,59`       | Temp files never cleaned up — resource leak                                             |
 | [ ]  | 6  | **High**     | `nodes/raw.rb:34`                | `add` mutates the caller's array                                                        |
 | [x]  | 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
-| [ ]  | 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
+| [x]  | 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
 | [ ]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
 | [ ]  | 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`             |

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -188,8 +188,8 @@ module Rambling
         root.key? letter
       end
 
-      # Size of the Root {Nodes::Node Node}'s children tree.
-      # @return [Integer] the number of letters in the root node.
+      # Number of words contained in the trie.
+      # @return [Integer] the number of words stored in the trie.
       def size
         root.size
       end

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -45,7 +45,7 @@ module Rambling
 
       def key?: (Symbol) -> bool
 
-      def size: -> Numeric
+      def size: -> Integer
 
       alias include? word?
       alias match? partial_word?

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -426,6 +426,18 @@ describe Rambling::Trie::Container do
     end
   end
 
+  describe '#size' do
+    before { add_words container, %w(hello high) }
+
+    it 'returns the number of words in the trie' do
+      expect(container.size).to eq 2
+    end
+
+    it 'does not return the number of letters in the root children tree' do
+      expect(container.size).not_to eq root.children_tree.size
+    end
+  end
+
   describe 'delegates and aliases' do
     before do
       allow(root).to receive_messages(


### PR DESCRIPTION
_Deals with issue no. 8 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Docs and type signature are out of sync for `Container#size`, and the docstring itself is not accurate.