### PR TITLE
Correct `Container#scan` alias in type sig from `words?` to `words`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Raise `ArgumentError` in `Container#concat` on words/values size mismatch ([#96][github_pull_96])
   by [@gonzedge][github_user_gonzedge]
 - Correct `Container#size` docs and RBS signature ([#97][github_pull_97]) by [@gonzedge][github_user_gonzedge]
+- Correct `Container#scan` alias in type sig from `words?` to `words` ([#98][github_pull_98])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1333,6 +1335,7 @@ Most of these help with the gem's overall performance.
 [github_pull_95]: https://github.com/gonzedge/rambling-trie/pull/95
 [github_pull_96]: https://github.com/gonzedge/rambling-trie/pull/96
 [github_pull_97]: https://github.com/gonzedge/rambling-trie/pull/97
+[github_pull_98]: https://github.com/gonzedge/rambling-trie/pull/98
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -16,7 +16,7 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 | [ ]  | 6  | **High**     | `nodes/raw.rb:34`                | `add` mutates the caller's array                                                        |
 | [x]  | 7  | **High**     | `container.rb:42`                | `concat` silently ignores `values` array length mismatch                                |
 | [x]  | 8  | **High**     | `container.rb:186`               | `size` counts words, docs claim it counts letters                                       |
-| [ ]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
+| [x]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
 | [ ]  | 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`             |
 | [ ]  | 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                      |

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -49,7 +49,7 @@ module Rambling
 
       alias include? word?
       alias match? partial_word?
-      alias words? scan
+      alias words scan
       alias << add
       alias has_key? key?
       alias has_letter? key?


### PR DESCRIPTION
_Deals with issue no. 9 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

`Container` type signature does not match the implementation, as `#scan` is aliased to `#words?` instead of `#words`. This PR corrects the alias in type sig from `words?` to `words`.