### PR TITLE
Add runtime security warnings to `Serializers::(Marshal|Yaml)#load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Correct `Container#size` docs and RBS signature ([#97][github_pull_97]) by [@gonzedge][github_user_gonzedge]
 - Correct `Container#scan` alias in type sig from `words?` to `words` ([#98][github_pull_98])
   by [@gonzedge][github_user_gonzedge]
+- Add runtime security warnings to `Serializers::(Marshal|Yaml)#load` ([#99][github_pull_99])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1336,6 +1338,7 @@ Most of these help with the gem's overall performance.
 [github_pull_96]: https://github.com/gonzedge/rambling-trie/pull/96
 [github_pull_97]: https://github.com/gonzedge/rambling-trie/pull/97
 [github_pull_98]: https://github.com/gonzedge/rambling-trie/pull/98
+[github_pull_99]: https://github.com/gonzedge/rambling-trie/pull/99
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -36,7 +36,7 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 | [ ]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                         |
 | [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                              |
 | [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                        |
-| [ ]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack                               |
+| [x]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack                               |
 | [ ]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` when already compressed — inconsistent identity               |
 
 ---

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -19,7 +19,7 @@ Reviewed by Claude (claude-sonnet-4-6) on 2026-04-11.
 | [x]  | 9  | **High**     | `container.rbs:53`               | `words?` alias in RBS does not match Ruby's `words`                                     |
 | [ ]  | 10 | **High**     | `nodes/compressed.rb:98`         | `children_match_prefix` silently truncates short prefix                                 |
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`             |
-| [ ]  | 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                      |
+| [x]  | 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                      |
 | [ ]  | 13 | **Medium**   | `stringifyable.rb:22`            | `to_s` has O(depth²) string allocations                                                 |
 | [ ]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick                              |
 | [ ]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`                                   |

--- a/lib/rambling/trie/serializers/marshal.rb
+++ b/lib/rambling/trie/serializers/marshal.rb
@@ -19,6 +19,11 @@ module Rambling
         # @note Use of {https://ruby-doc.org/3.3.0/Marshal.html#method-c-load Marshal.load} is generally
         #   discouraged. Only use this with trusted input.
         def load filepath
+          warn <<~WARN.chomp.gsub(/\n/, ' ')
+            WARNING: Marshal.load is being used to deserialize trie data.
+            Loading untrusted input via Marshal.load can execute arbitrary code.
+            Only load Marshal data from trusted sources.
+WARN
           ::Marshal.load serializer.load filepath
         end
 

--- a/lib/rambling/trie/serializers/marshal.rb
+++ b/lib/rambling/trie/serializers/marshal.rb
@@ -19,11 +19,11 @@ module Rambling
         # @note Use of {https://ruby-doc.org/3.3.0/Marshal.html#method-c-load Marshal.load} is generally
         #   discouraged. Only use this with trusted input.
         def load filepath
-          warn <<~WARN.chomp.gsub(/\n/, ' ')
+          warn <<~WARN.chomp.tr("\n", ' ')
             WARNING: Marshal.load is being used to deserialize trie data.
             Loading untrusted input via Marshal.load can execute arbitrary code.
             Only load Marshal data from trusted sources.
-WARN
+          WARN
           ::Marshal.load serializer.load filepath
         end
 

--- a/lib/rambling/trie/serializers/yaml.rb
+++ b/lib/rambling/trie/serializers/yaml.rb
@@ -17,11 +17,11 @@ module Rambling
         # @return [Nodes::Node] The deserialized {Nodes::Node Node}.
         # @see https://ruby-doc.org/3.3.0/exts/psych/Psych.html#method-c-safe_load Psych.safe_load
         def load filepath
-          warn <<~WARN.chomp.gsub(/\n/, ' ')
+          warn <<~WARN.chomp.tr("\n", ' ')
             WARNING: YAML aliases are enabled.
             Loading untrusted YAML with aliases: true can trigger a billion-laughs memory attack.
             Only load YAML data from trusted sources.
-WARN
+          WARN
           require 'yaml'
           ::YAML.safe_load(
             serializer.load(filepath),

--- a/lib/rambling/trie/serializers/yaml.rb
+++ b/lib/rambling/trie/serializers/yaml.rb
@@ -17,6 +17,11 @@ module Rambling
         # @return [Nodes::Node] The deserialized {Nodes::Node Node}.
         # @see https://ruby-doc.org/3.3.0/exts/psych/Psych.html#method-c-safe_load Psych.safe_load
         def load filepath
+          warn <<~WARN.chomp.gsub(/\n/, ' ')
+            WARNING: YAML aliases are enabled.
+            Loading untrusted YAML with aliases: true can trigger a billion-laughs memory attack.
+            Only load YAML data from trusted sources.
+WARN
           require 'yaml'
           ::YAML.safe_load(
             serializer.load(filepath),

--- a/spec/lib/rambling/trie/serializers/marshal_spec.rb
+++ b/spec/lib/rambling/trie/serializers/marshal_spec.rb
@@ -7,4 +7,24 @@ describe Rambling::Trie::Serializers::Marshal do
     let(:file_format) { :marshal }
     let(:format_content) { Marshal.method(:dump) }
   end
+
+  describe 'marshal-only behavior' do
+    describe '#load' do
+      subject(:serializer) { described_class.new }
+
+      let(:trie) { Rambling::Trie.create }
+      let(:tmp_path) { File.join SPEC_ROOT, 'tmp' }
+      let(:filepath) { File.join tmp_path, 'trie-root.marshal' }
+
+      before do
+        trie.concat %w(hello world)
+        serializer.dump trie.root, filepath
+      end
+
+      it 'emits a security warning to stderr' do
+        expect { serializer.load filepath }
+          .to output(%r{Marshal\.load.*untrusted}i).to_stderr
+      end
+    end
+  end
 end

--- a/spec/lib/rambling/trie/serializers/yaml_spec.rb
+++ b/spec/lib/rambling/trie/serializers/yaml_spec.rb
@@ -7,4 +7,22 @@ describe Rambling::Trie::Serializers::Yaml do
     let(:file_format) { :yml }
     let(:format_content) { YAML.method(:dump) }
   end
+
+  describe '#load security warning' do
+    subject(:serializer) { described_class.new }
+
+    let(:trie) { Rambling::Trie.create }
+    let(:tmp_path) { File.join SPEC_ROOT, 'tmp' }
+    let(:filepath) { File.join tmp_path, 'trie-root.yml' }
+
+    before do
+      trie.concat %w(hello world)
+      serializer.dump trie.root, filepath
+    end
+
+    it 'emits a security warning to stderr' do
+      expect { serializer.load filepath }
+        .to output(%r{aliases.*billion.laughs}i).to_stderr
+    end
+  end
 end


### PR DESCRIPTION
_Deals with issues no. 12 and 29 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Both `Serializers::Marshal`'s and `Serializers::Yaml`'s `#load` method perform risky loads of input streams. This PR adds `warn`s for the users, to ensure they take proper care when using these in the wild.