### PR TITLE
Fix some idioms, style and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
   by [@gonzedge][github_user_gonzedge]
 - Stop early in `Nodes::Compressed#match_prefix` when chars does not cover the node's compressed key
   ([#101][github_pull_101]) by [@gonzedge][github_user_gonzedge]
+- Fix some idioms, styles and docstrings ([#102][github_pull_102]) by [@gonzedge][github_user_gonzedge]
+  - Use `each_value.first` in `Nodes::Node#first_child` instead of the workaround that triggered rubocop's
+    `Lint/UnreacheableLoop` rule
+  - Replace Yoda condition `1 == children_tree.size` with `children_tree.one?` in `Compressible#compressible?`
+  - Fix copy-pasta dosctring for `Nodes::Node#value`
+  - Use inline guard for `Stringifyable#as_word`
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1345,6 +1351,7 @@ Most of these help with the gem's overall performance.
 [github_pull_99]: https://github.com/gonzedge/rambling-trie/pull/99
 [github_pull_100]: https://github.com/gonzedge/rambling-trie/pull/100
 [github_pull_101]: https://github.com/gonzedge/rambling-trie/pull/101
+[github_pull_102]: https://github.com/gonzedge/rambling-trie/pull/102
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -34,7 +34,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem                                            |
 | [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                                         |
 | [ ]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree — REPL/logging hazard on large tries                               |
-| [ ]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                                       |
+| [x]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                                       |
 | [ ]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                                        |
 | [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                                             |
 | [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                                       |

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -23,7 +23,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`               | Shared `children_tree` hash mutated via parent reassignment in `Compressed`                            |
 | [x]  | 12 | **High**     | `serializers/marshal.rb`         | `Marshal.load` security risk with no runtime guard                                                     |
 | [-]  | 13 | **Medium**   | `stringifyable.rb:22`            | `to_s` has O(depth²) string allocations - _**DISCARDED**, see [#100][github_pull_100]_                 |
-| [ ]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick                                             |
+| [x]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick                                             |
 | [ ]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`                                                  |
 | [ ]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                                                             |
 | [ ]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations in `reversed_char_symbols`                |

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -34,7 +34,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem                                            |
 | [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                                         |
 | [ ]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree — REPL/logging hazard on large tries                               |
-| [x]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                                       |
+| [-]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition - _**NOT QUITE**, see [#102][github_pull_102]         |
 | [x]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                                        |
 | [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                                             |
 | [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                                       |
@@ -575,3 +575,4 @@ no work is needed). `compress!` is the correct mutation path.
 
 [github_pull_100]: https://github.com/gonzedge/rambling-trie/pull/100
 [github_pull_101]: https://github.com/gonzedge/rambling-trie/pull/101
+[github_pull_102]: https://github.com/gonzedge/rambling-trie/pull/102

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -35,7 +35,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                                         |
 | [ ]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree — REPL/logging hazard on large tries                               |
 | [x]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                                                       |
-| [ ]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                                        |
+| [x]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description                                        |
 | [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given                                             |
 | [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                                                       |
 | [x]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack                                              |

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -29,7 +29,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations in `reversed_char_symbols`                |
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context                                      |
 | [ ]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections                                           |
-| [ ]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                                                               |
+| [x]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                                                               |
 | [ ]  | 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent                                               |
 | [ ]  | 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem                                            |
 | [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                                                         |

--- a/lib/rambling/trie/compressible.rb
+++ b/lib/rambling/trie/compressible.rb
@@ -7,7 +7,7 @@ module Rambling
       # Indicates if the current {Rambling::Trie::Nodes::Node Node} can be compressed or not.
       # @return [Boolean] `true` for non-{Nodes::Node#terminal? terminal} nodes with one child, `false` otherwise.
       def compressible?
-        !(root? || terminal?) && 1 == children_tree.size
+        !(root? || terminal?) && children_tree.one?
       end
     end
   end

--- a/lib/rambling/trie/compressible.rb
+++ b/lib/rambling/trie/compressible.rb
@@ -7,7 +7,7 @@ module Rambling
       # Indicates if the current {Rambling::Trie::Nodes::Node Node} can be compressed or not.
       # @return [Boolean] `true` for non-{Nodes::Node#terminal? terminal} nodes with one child, `false` otherwise.
       def compressible?
-        !(root? || terminal?) && children_tree.one?
+        !root? && !terminal? && children_tree.one?
       end
     end
   end

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -54,13 +54,7 @@ module Rambling
         # First child node.
         # @return [Node, nil] the first child contained in the current node.
         def first_child
-          return if children_tree.empty?
-
-          # rubocop:disable Lint/UnreachableLoop
-          children_tree.each_value { |child| return child }
-          # rubocop:enable Lint/UnreachableLoop
-
-          nil
+          children_tree.each_value.first
         end
 
         # Indicates if the current node is the root node.

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -32,7 +32,7 @@ module Rambling
         attr_accessor :parent
 
         # Arbitrary value stored in this node
-        # @return [TValue, nil] the parent of the current node.
+        # @return [TValue, nil] the value stored in this node.
         attr_accessor :value
 
         # Creates a new node.

--- a/lib/rambling/trie/stringifyable.rb
+++ b/lib/rambling/trie/stringifyable.rb
@@ -8,10 +8,7 @@ module Rambling
       # @return [String] the string representation of the current node.
       # @raise [InvalidOperation] if node is not terminal or is root.
       def as_word
-        if letter && !terminal?
-          raise Rambling::Trie::InvalidOperation,
-            'Cannot represent branch as a word'
-        end
+        raise Rambling::Trie::InvalidOperation, 'Cannot represent branch as a word' if letter && !terminal?
 
         to_s
       end

--- a/spec/lib/rambling/trie/compressible_spec.rb
+++ b/spec/lib/rambling/trie/compressible_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Rambling::Trie::Compressible do
+  describe '#compressible?' do
+    context 'with a raw node' do
+      let(:node) { Rambling::Trie::Nodes::Raw.new }
+
+      context 'when the node has one non-terminal child' do
+        before { add_word node, 'ab' }
+
+        it 'returns true for the single-child node' do
+          expect(node[:a]).to be_compressible
+        end
+      end
+
+      context 'when the node has more than one child' do
+        before { add_words node, %w(ab ac) }
+
+        it 'returns false' do
+          expect(node[:a]).not_to be_compressible
+        end
+      end
+
+      context 'when the node is terminal' do
+        before { add_word node, 'a' }
+
+        it 'returns false' do
+          expect(node[:a]).not_to be_compressible
+        end
+      end
+
+      context 'when the node is root' do
+        it 'returns false' do
+          expect(node).not_to be_compressible
+        end
+      end
+    end
+
+    context 'with a compressed node' do
+      let(:raw_node) { Rambling::Trie::Nodes::Raw.new }
+      let(:compressor) { Rambling::Trie::Compressor.new }
+
+      context 'when the node has single terminal compressed child' do
+        before { add_word raw_node, 'ab' }
+
+        let(:node) { compressor.compress raw_node }
+
+        it 'returns false' do
+          expect(node[:a]).not_to be_compressible
+        end
+      end
+
+      context 'when the node has many children causing effectively no compression' do
+        before { add_words raw_node, %w(ab ac) }
+
+        let(:node) { compressor.compress raw_node }
+
+        it 'returns false' do
+          expect(node[:a]).not_to be_compressible
+        end
+      end
+
+      context 'when the node is root' do
+        let(:node) { compressor.compress raw_node }
+
+        it 'returns false' do
+          expect(node).not_to be_compressible
+        end
+      end
+    end
+
+    context 'with a compressed node in an in-between state' do
+      let(:node) { Rambling::Trie::Nodes::Compressed.new }
+      let(:in_between_child) { Rambling::Trie::Nodes::Compressed.new :hel, node }
+
+      before { node[:h] = in_between_child }
+
+      context 'when there is only one child and it is terminal' do
+        let(:hello_child) { Rambling::Trie::Nodes::Compressed.new :lo, in_between_child }
+
+        before { in_between_child[:l] = hello_child }
+
+        it 'returns true for the in-between child' do
+          expect(node[:h]).to be_compressible
+        end
+
+        it 'returns false for the terminal child' do
+          expect(node[:h][:l]).not_to be_compressible
+        end
+      end
+
+      context 'when there are multiple terminal children' do
+        let(:hello_child) { Rambling::Trie::Nodes::Compressed.new :lo, in_between_child }
+        let(:help_child) { Rambling::Trie::Nodes::Compressed.new :p, in_between_child }
+
+        before do
+          in_between_child[:l] = hello_child
+          in_between_child[:p] = help_child
+        end
+
+        it 'returns false for the in-between child' do
+          expect(node[:h]).not_to be_compressible
+        end
+
+        %i(l p).each do |letter|
+          it "returns false for the terminal node #{letter}" do
+            expect(node[:h][letter]).not_to be_compressible
+          end
+        end
+      end
+
+      context 'when the node is root' do
+        it 'returns false' do
+          expect(node).not_to be_compressible
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/a_trie_node.rb
+++ b/spec/support/shared_examples/a_trie_node.rb
@@ -16,6 +16,10 @@ shared_examples_for 'a trie node' do
       expect(node).not_to be_terminal
     end
 
+    it 'has no first_child' do
+      expect(node.first_child).to be_nil
+    end
+
     it 'has no value' do
       expect(node.value).to be_nil
     end
@@ -38,6 +42,10 @@ shared_examples_for 'a trie node' do
 
       it 'is not terminal' do
         expect(node_with_parent).not_to be_terminal
+      end
+
+      it 'has no first_child' do
+        expect(node.first_child).to be_nil
       end
     end
   end

--- a/spec/support/shared_examples/a_trie_node_implementation.rb
+++ b/spec/support/shared_examples/a_trie_node_implementation.rb
@@ -3,6 +3,24 @@
 shared_examples_for 'a trie node implementation' do
   it_behaves_like 'a trie node'
 
+  describe '#first_child' do
+    context 'when the node has no children' do
+      it 'returns nil' do
+        expect(node.first_child).to be_nil
+      end
+    end
+
+    context 'when the node has children' do
+      let(:raw_node) { Rambling::Trie::Nodes::Raw.new }
+
+      before { add_word raw_node, 'hi' }
+
+      it 'returns the first child node' do
+        expect(raw_node.first_child).to eq raw_node[:h]
+      end
+    end
+  end
+
   describe '#partial_word?' do
     context 'when the chars array is empty' do
       it 'returns true' do


### PR DESCRIPTION
_A few issues captured in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md) are just style, typos and non-idiomatic ways of doing things._

This PR addresses a few that did not warrant their own individual PRs:

- Use `each_value.first` in `Nodes::Node#first_child` instead of the workaround that triggered rubocop's `Lint/UnreacheableLoop` rule - _deals with issue no 14_
- Replace Yoda condition `1 == children_tree.size` with `children_tree.one?` in `Compressible#compressible?` - _deals with issue no 20_
- Fix copy-pasta dosctring for `Nodes::Node#value` - _deals with issue no 26_
- Use inline conditional for `Stringifyable#as_word` - _related to issue no 25, though not really_

## Issue 25

I'm discarding it because, it says;

> The condition means *"has a letter AND is not terminal"*, but `!terminal?` forces a double-negative parse. A guard
> clause form is both idiomatic and easier to read:
> ...

But it's not a double-negative? Maybe it's figuring out that `terminal?` is defined as `!!terminal`, but any suggestions don't really deal with that:
```ruby
# replace with guard
raise X if letter && !terminal?
# replace with unless guard
raise X unless !letter || terminal?
# replace with guard after extracting a new "branch?" method that defined as "!terminal?"
raise X if letter && branch?
```
