### PR TITLE
Handle tmp dir compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Fix `Serializers::Zip#(load|dump)` leaking tmp files ([#95][github_pull_95]) by [@gonzedge][github_user_gonzedge]
   - Add common `Serializer::Zip#clean_up_tmp_files` method
   - Use `(serializers.resolve(filename) || raise).<method>` trick to reduce method sizes
+- Handle tmp dir compatibility issues ([#104][github_pull_104]) by [@gonzedge][github_user_gonzedge]
+  - Replace hardcoded `/tmp` with `Dir.tmpdir` in `Properties`
+  - Rename `Serializers::Zip#path{,_with_random_prefix}` to better communicate intent
 
 #### Minor
 
@@ -1352,6 +1355,8 @@ Most of these help with the gem's overall performance.
 [github_pull_100]: https://github.com/gonzedge/rambling-trie/pull/100
 [github_pull_101]: https://github.com/gonzedge/rambling-trie/pull/101
 [github_pull_102]: https://github.com/gonzedge/rambling-trie/pull/102
+[github_pull_103]: https://github.com/gonzedge/rambling-trie/pull/103
+[github_pull_104]: https://github.com/gonzedge/rambling-trie/pull/104
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/Steepfile
+++ b/Steepfile
@@ -19,6 +19,7 @@ target :lib do
   library 'rake'
   library 'yaml'
   library 'securerandom'
+  library 'tmpdir'
 
   # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -30,7 +30,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context  |                                   |
 | [ ]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections       |                                   |
 | [x]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                           | [#102][gh_102]                    |
-| [ ]  | 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent           |                                   |
+| [x]  | 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent           | [#104][gh_104]                    |
 | [ ]  | 22 | **Medium**   | `trie.rb:24,27`                  | Two `# noinspection` comments masking a type design problem        |                                   |
 | [ ]  | 23 | **Medium**   | `provider_collection.rb:73`      | `reset` can unexpectedly raise `ArgumentError`                     |                                   |
 | [-]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree                                | [feedback][fb_24]                 |

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -37,7 +37,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [-]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                   | [feedback][fb_25], [#102][gh_102] |
 | [x]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description    | [#102][gh_102]                    |
 | [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given         |                                   |
-| [ ]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                   |                                   |
+| [x]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                   | [#104][gh_104]                    |
 | [x]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack          | [#99][gh_99]                      |
 | [ ]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` after compressed — inconsistent identity |                                   |
 
@@ -693,4 +693,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_100]: https://github.com/gonzedge/rambling-trie/pull/100
 [gh_101]: https://github.com/gonzedge/rambling-trie/pull/101
 [gh_102]: https://github.com/gonzedge/rambling-trie/pull/102
+[gh_104]: https://github.com/gonzedge/rambling-trie/pull/104
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/configuration/properties.rb
+++ b/lib/rambling/trie/configuration/properties.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 module Rambling
   module Trie
     module Configuration
@@ -39,7 +41,7 @@ module Rambling
 
           @compressor = Rambling::Trie::Compressor.new
           @root_builder = -> { Rambling::Trie::Nodes::Raw.new }
-          @tmp_path = '/tmp'
+          @tmp_path = Dir.tmpdir
         end
 
         private

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -30,7 +30,7 @@ module Rambling
               raise unless entry
 
               entry_name = entry.name
-              entry_path = path entry_name
+              entry_path = path_with_random_prefix entry_name
               tmp_paths << entry_path
 
               entry.extract ::File.basename(entry_path), destination_directory: tmp_path
@@ -53,7 +53,7 @@ module Rambling
             ::Zip::File.open filepath, create: true do |zip|
               filename = ::File.basename filepath, '.zip'
 
-              entry_path = path filename
+              entry_path = path_with_random_prefix filename
               tmp_paths << entry_path
 
               (serializers.resolve(filename) || raise).dump contents, entry_path
@@ -76,7 +76,7 @@ module Rambling
           properties.tmp_path
         end
 
-        def path filename
+        def path_with_random_prefix filename
           require 'securerandom'
           ::File.join tmp_path, "#{SecureRandom.uuid}-#{filename}"
         end

--- a/sig/lib/rambling/trie/serializers/zip.rbs
+++ b/sig/lib/rambling/trie/serializers/zip.rbs
@@ -14,7 +14,7 @@ module Rambling
 
         def tmp_path: -> String
 
-        def path: (String) -> String
+        def path_with_random_prefix: (String) -> String
 
         def clean_up_tmp_files: [T] { (Array[String]) -> T } -> T
       end

--- a/spec/lib/rambling/trie/configuration/properties_spec.rb
+++ b/spec/lib/rambling/trie/configuration/properties_spec.rb
@@ -38,6 +38,10 @@ describe Rambling::Trie::Configuration::Properties do
       root = properties.root_builder.call
       expect(root).to be_instance_of Rambling::Trie::Nodes::Raw
     end
+
+    it 'configures tmp_path to the system temp directory' do
+      expect(properties.tmp_path).to eq Dir.tmpdir
+    end
   end
 
   describe '#reset' do


### PR DESCRIPTION
_Deals with issues 21 and 28 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

The current `/tmp` path is not cross-OS compatible 😬 

This PR:
- Replaces hardcoded `/tmp` with `Dir.tmpdir` in `Properties`
- Renames `Serializers::Zip#path{,_with_random_prefix}` to better communicate intent