### PR TITLE
Return `self` from `Container#each` after block (ruby convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   - Replace Yoda condition `1 == children_tree.size` with `children_tree.one?` in `Compressible#compressible?`
   - Fix copy-pasta dosctring for `Nodes::Node#value`
   - Use inline guard for `Stringifyable#as_word`
+- Return `self` from `Container#each` after block (ruby convention) ([#105][github_pull_105])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1357,6 +1359,7 @@ Most of these help with the gem's overall performance.
 [github_pull_102]: https://github.com/gonzedge/rambling-trie/pull/102
 [github_pull_103]: https://github.com/gonzedge/rambling-trie/pull/103
 [github_pull_104]: https://github.com/gonzedge/rambling-trie/pull/104
+[github_pull_105]: https://github.com/gonzedge/rambling-trie/pull/105
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -36,7 +36,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [-]  | 24 | **Low**      | `container.rb:137`               | `inspect` traverses the entire tree                                | [feedback][fb_24]                 |
 | [-]  | 25 | **Low**      | `stringifyable.rb:11`            | `as_word` guard uses a double-negative condition                   | [feedback][fb_25], [#102][gh_102] |
 | [x]  | 26 | **Low**      | `nodes/node.rb:35`               | `value` docstring copy-pasted from `parent` — wrong description    | [#102][gh_102]                    |
-| [ ]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given         |                                   |
+| [x]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given         | [#105][gh_105]                    |
 | [x]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                   | [#104][gh_104]                    |
 | [x]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack          | [#99][gh_99]                      |
 | [ ]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` after compressed — inconsistent identity |                                   |
@@ -694,4 +694,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_101]: https://github.com/gonzedge/rambling-trie/pull/101
 [gh_102]: https://github.com/gonzedge/rambling-trie/pull/102
 [gh_104]: https://github.com/gonzedge/rambling-trie/pull/104
+[gh_105]: https://github.com/gonzedge/rambling-trie/pull/105
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -137,6 +137,8 @@ module Rambling
         return enum_for :each unless block_given?
 
         root.each { |word| yield word }
+
+        self
       end
 
       # @return [String] a string representation of the container.

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -18,6 +18,7 @@ module Rambling
       def compress: -> Container[TValue]
 
       def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable[TValue])
+                | -> Container[TValue]
 
       def partial_word?: (String) -> bool
 

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -405,12 +405,19 @@ describe Rambling::Trie::Container do
       expect(yielded).to eq %w(yes no why)
     end
 
-    it 'returns an enumerator when no block is given' do
-      expect(container.each).to be_instance_of Enumerator
+    it 'returns self' do
+      result = container.each { |word| word }
+      expect(result).to be container
     end
 
-    it 'iterates through all words contained' do
-      expect(container.each.to_a).to eq %w(yes no why)
+    context 'when no block is given' do
+      it 'returns an enumerator when no block is given' do
+        expect(container.each).to be_instance_of Enumerator
+      end
+
+      it 'iterates through all words contained' do
+        expect(container.each.to_a).to eq %w(yes no why)
+      end
     end
   end
 


### PR DESCRIPTION
_Deals with issue no. 27 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

Currently, the underlying root node is being returned at the end of a `Container#each` call with a block. This PR changes that to return `self` instead, and updates the signatures and tests accordingly.