### PR TITLE
Reduce allocs in `reversed_char_symbols` and remove no-op `.to_a` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
   - Use inline guard for `Stringifyable#as_word`
 - Return `self` from `Container#each` after block (ruby convention) ([#105][github_pull_105])
   by [@gonzedge][github_user_gonzedge]
+- Reduce allocs in `reversed_char_symbols` and remove no-op `.to_a` ([#106][github_pull_106])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1360,6 +1362,7 @@ Most of these help with the gem's overall performance.
 [github_pull_103]: https://github.com/gonzedge/rambling-trie/pull/103
 [github_pull_104]: https://github.com/gonzedge/rambling-trie/pull/104
 [github_pull_105]: https://github.com/gonzedge/rambling-trie/pull/105
+[github_pull_106]: https://github.com/gonzedge/rambling-trie/pull/106
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -26,7 +26,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick         | [#102][gh_102]                    |
 | [-]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`              | [feedback][fb_15]                 |
 | [ ]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                         |                                   |
-| [ ]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations       |                                   |
+| [x]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations       | [#106][gh_106]                    |
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context  |                                   |
 | [ ]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections       |                                   |
 | [x]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                           | [#102][gh_102]                    |
@@ -695,4 +695,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_102]: https://github.com/gonzedge/rambling-trie/pull/102
 [gh_104]: https://github.com/gonzedge/rambling-trie/pull/104
 [gh_105]: https://github.com/gonzedge/rambling-trie/pull/105
+[gh_106]: https://github.com/gonzedge/rambling-trie/pull/106
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -226,7 +226,10 @@ module Rambling
       end
 
       def reversed_char_symbols word
-        word.reverse.chars.map(&:to_sym).to_a
+        # @type var chars: Array[String]
+        chars = word.chars
+        chars.reverse!
+        chars.map(&:to_sym)
       end
     end
   end

--- a/tasks/ips.rb
+++ b/tasks/ips.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 namespace :ips do
+  task :reverse_chars_map_to_a_vs_chars_in_place_reverse_map do
+    compare_reverse_chars_map_to_a_vs_chars_in_place_reverse_map
+  end
+
   task :to_s_recursive_vs_iterative do
     compare_to_s_recursive_vs_iterative
   end
@@ -79,6 +83,20 @@ def compare
     ::GC.enable
 
     bm.compare!
+  end
+end
+
+def compare_reverse_chars_map_to_a_vs_chars_in_place_reverse_map
+  compare do |bm|
+    word = 'dumbfoundedly'
+    word.chars.each(&:to_sym) # <- make sure the symbols are already initialized
+
+    bm.report('word.reverse.chars.map(&:to_sym).to_a') { word.reverse.chars.map(&:to_sym).to_a }
+    bm.report('word.chars.reverse!.map(&:to_sym)') do
+      chars = word.chars
+      chars.reverse!
+      chars.map(&:to_sym)
+    end
   end
 end
 


### PR DESCRIPTION
_Deals with issue no. 17 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md)._

After running a benchmark, it looks like it is indeed faster to get the chars, do the reverse in place and then map, than it is to reverse the word, get the chars, then map plus no-op `to_a`!

---

### Benchmark

```
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [x86_64-darwin25]
Warming up --------------------------------------
word.reverse.chars.map(&:to_sym).to_a
                        41.131k i/100ms
word.chars.reverse!.map(&:to_sym)
                        43.101k i/100ms
Calculating -------------------------------------
word.reverse.chars.map(&:to_sym).to_a
                        409.879k (± 1.0%) i/s    (2.44 μs/i) -      2.057M in   5.017970s
word.chars.reverse!.map(&:to_sym)
                        429.534k (± 1.1%) i/s    (2.33 μs/i) -      2.155M in   5.017765s

Comparison:
word.chars.reverse!.map(&:to_sym):   429533.7 i/s
word.reverse.chars.map(&:to_sym).to_a:   409878.6 i/s - 1.05x  slower
```