### PR TITLE
Fix `Nodes::Compressed#{partial_word_chars?,closest_node}` same-length non-matching prefix regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@
 - Remove unnecessary `providers.any?` guard and `ProviderCollection#contains?` ([#107][github_pull_107])
   by [@gonzedge][github_user_gonzedge]
 - Better type resolution within `Rambling::Trie.create` ([#108][github_pull_108]) by [@gonzedge][github_user_gonzedge]
+- Fix `Nodes::Compressed#{partial_word_chars?,closest_node}` same-length non-matching prefix regression
+  ([#109][github_pull_109]) by [@gonzedge][github_user_gonzedge]
+  - Make the `chars.size >= child_letter.size` branch mutually exclusive with the short-prefix branch; the shift mutates
+    `chars`, so fall-through was incorrectly passing an empty `chars` to the second comparison
+  - Add regression specs for `partial_word?`/`scan` on diverging same-length queries like `hallo`/`wolld`
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1366,6 +1371,9 @@ Most of these help with the gem's overall performance.
 [github_pull_104]: https://github.com/gonzedge/rambling-trie/pull/104
 [github_pull_105]: https://github.com/gonzedge/rambling-trie/pull/105
 [github_pull_106]: https://github.com/gonzedge/rambling-trie/pull/106
+[github_pull_107]: https://github.com/gonzedge/rambling-trie/pull/107
+[github_pull_108]: https://github.com/gonzedge/rambling-trie/pull/108
+[github_pull_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -54,7 +54,10 @@ def partial_word_chars? chars
 end
 ```
 
-When `chars.size >= child_letter.size` **and** the shifted prefix does not equal `child_letter`, the method falls through to the second check — but by that point `chars.shift(child_letter.size)` has already mutated `chars`. If `chars.size` was exactly equal to `child_letter.size`, `chars` is now empty, `letter = ''`, `child_letter.slice(0, 0) = ''`, and the method incorrectly returns `true`.
+When `chars.size >= child_letter.size` **and** the shifted prefix does not equal `child_letter`, the method falls
+through to the second check — but by that point `chars.shift(child_letter.size)` has already mutated `chars`. If
+`chars.size` was exactly equal to `child_letter.size`, `chars` is now empty, `letter = ''`, `child_letter.slice(0, 0) =
+''`, and the method incorrectly returns `true`.
 
 **Reproduction:**
 
@@ -67,7 +70,8 @@ trie.partial_word? 'hexyo'   # => true  (expected: false)
 trie.match? 'hallo'          # => true  (alias of partial_word?, same bug)
 ```
 
-Also reproducible on any trie where a compressed child's letter length equals the query length and the first char matches but later chars diverge:
+Also reproducible on any trie where a compressed child's letter length equals the query length and the first char
+matches but later chars diverge:
 
 ```ruby
 trie = Rambling::Trie.create
@@ -77,7 +81,8 @@ trie.partial_word? 'hallo'   # => true  (expected: false)
 trie.partial_word? 'wolld'   # => true  (expected: false)
 ```
 
-**Root cause:** The `if` block mutates `chars` via `shift`, but the fall-through path uses the same mutated `chars` — it was designed for the `chars.size < child_letter.size` case where no shift happened.
+**Root cause:** The `if` block mutates `chars` via `shift`, but the fall-through path uses the same mutated `chars` — it
+was designed for the `chars.size < child_letter.size` case where no shift happened.
 
 **Fix:** Make the two branches mutually exclusive, e.g.:
 
@@ -92,9 +97,12 @@ else
 end
 ```
 
-This bug was not caught by the existing specs because `a_container_partial_word` tests only cover prefixes with `chars.size < child_letter.size` (`ha`, `hal`, `al`) and the integration tests use multi-child tries where the first char triggers a single-char compressed key (`:h`) that defers the match deeper.
+This bug was not caught by the existing specs because `a_container_partial_word` tests only cover prefixes with
+`chars.size < child_letter.size` (`ha`, `hal`, `al`) and the integration tests use multi-child tries where the first
+char triggers a single-char compressed key (`:h`) that defers the match deeper.
 
-The same pattern exists in `match_child_prefix` (lines 100-112) but is correctly guarded there by `return empty_enum if chars.size < child_letter.size` — which returns early, avoiding the fall-through.
+The same pattern exists in `match_child_prefix` (lines 100-112) but is correctly guarded there by `return empty_enum if
+chars.size < child_letter.size` — which returns early, avoiding the fall-through.
 
 ---
 
@@ -121,7 +129,8 @@ def closest_node chars
 end
 ```
 
-Identical structural bug to issue 31. When `chars.size == child_letter.size` and the shifted letter does not match, `chars` is emptied, `letter = ''` and `child_letter = ''`, so the method returns `child` instead of `missing`.
+Identical structural bug to issue 31. When `chars.size == child_letter.size` and the shifted letter does not match,
+`chars` is emptied, `letter = ''` and `child_letter = ''`, so the method returns `child` instead of `missing`.
 
 **Reproduction:**
 
@@ -133,7 +142,8 @@ trie.scan 'hallo'      # => ["hello"]   (expected: [])
 trie.words 'hallo'     # => ["hello"]   (alias of scan, same bug)
 ```
 
-**Fix:** Same structural change as issue 31 — make the branches mutually exclusive so the fall-through only runs when no shift occurred.
+**Fix:** Same structural change as issue 31 — make the branches mutually exclusive so the fall-through only runs when no
+shift occurred.
 
 ---
 
@@ -143,7 +153,9 @@ trie.words 'hallo'     # => ["hello"]   (alias of scan, same bug)
 
 **File:** `lib/rambling/trie/nodes/node.rb:42`, `nodes/compressed.rb:13-18`
 
-`Compressed#initialize` forwards the caller's `children_tree` hash directly to `super` and then iterates it to set each child's `parent = self`. If the same hash object is ever shared with another node (e.g. constructing compressed nodes from existing subtrees), the parent reassignment silently rewires the other node's children.
+`Compressed#initialize` forwards the caller's `children_tree` hash directly to `super` and then iterates it to set each
+child's `parent = self`. If the same hash object is ever shared with another node (e.g. constructing compressed nodes
+from existing subtrees), the parent reassignment silently rewires the other node's children.
 
 Still unfixed in the current HEAD:
 
@@ -154,7 +166,9 @@ def initialize letter = nil, parent = nil, children_tree = {}
 end
 ```
 
-**Fix:** Either dup the tree, or dup the children, in the `Compressed` constructor. The `Compressor` is the only internal caller and it already builds fresh trees — but the constructor itself is public and becomes a footgun for direct users.
+**Fix:** Either dup the tree, or dup the children, in the `Compressed` constructor. The `Compressor` is the only
+internal caller and it already builds fresh trees — but the constructor itself is public and becomes a footgun for
+direct users.
 
 ---
 
@@ -182,7 +196,8 @@ So:
 - **Block-given overload** should return `Container[TValue]` (returns `self`) — RBS says `Enumerator | Enumerable`.
 - **No-block overload** should return `Enumerator[String, void]` — RBS says `Container[TValue]`.
 
-They are inverted. Steep silently accepts the wrong inference in both directions, masking future regressions (including the `Container#each returns self` fix from PR #105).
+They are inverted. Steep silently accepts the wrong inference in both directions, masking future regressions (including
+the `Container#each returns self` fix from PR #105).
 
 **Fix:**
 
@@ -191,7 +206,8 @@ def each: { (String) -> void } -> Container[TValue]
         | -> Enumerator[String, void]
 ```
 
-The same "returns `self` (or `Enumerable[TValue]`) when block given" confusion exists on the module at `sig/lib/rambling/trie/enumerable.rbs:8`. Worth auditing together.
+The same "returns `self` (or `Enumerable[TValue]`) when block given" confusion exists on the module at
+`sig/lib/rambling/trie/enumerable.rbs:8`. Worth auditing together.
 
 ---
 
@@ -203,9 +219,12 @@ The same "returns `self` (or `Enumerable[TValue]`) when block given" confusion e
 def each_word: (String) { (String?) -> void } -> (Enumerator[String?, void] | PlainText)
 ```
 
-The Ruby code was fixed in PR #91 to use `line.chomp!` followed by `yield line` — so the yielded value is always a `String`. The nullable `String?` here is a leftover from the pre-fix signature (`yield line.chomp!` used to return `nil` when nothing was trimmed).
+The Ruby code was fixed in PR #91 to use `line.chomp!` followed by `yield line` — so the yielded value is always a
+`String`. The nullable `String?` here is a leftover from the pre-fix signature (`yield line.chomp!` used to return `nil`
+when nothing was trimmed).
 
-**Effect:** Consumers like `Rambling::Trie.create` that type-check the block argument are forced to treat every word as possibly `nil` — defeating the point of the fix and silently propagating the old stale contract.
+**Effect:** Consumers like `Rambling::Trie.create` that type-check the block argument are forced to treat every word as
+possibly `nil` — defeating the point of the fix and silently propagating the old stale contract.
 
 **Fix:**
 
@@ -213,7 +232,8 @@ The Ruby code was fixed in PR #91 to use `line.chomp!` followed by `yield line` 
 def each_word: (String) { (String) -> void } -> (Enumerator[String, void] | PlainText)
 ```
 
-Also affects the base `Reader` signature at `sig/lib/rambling/trie/readers/reader.rbs:5` (uses non-nullable `String`, so the subclass is *narrower* than the parent in the wrong direction — a contravariance issue on the block parameter).
+Also affects the base `Reader` signature at `sig/lib/rambling/trie/readers/reader.rbs:5` (uses non-nullable `String`, so
+the subclass is *narrower* than the parent in the wrong direction — a contravariance issue on the block parameter).
 
 ---
 
@@ -231,7 +251,9 @@ Parent `Node#add` (`sig/lib/rambling/trie/nodes/raw.rbs:5` and `node.rbs:18`):
 def add: (Array[Symbol], ?TValue?) -> Node[TValue]
 ```
 
-The subclass drops the `?` on the second parameter, claiming nil is *not* accepted — but at runtime `Compressed#add` accepts anything and immediately raises `InvalidOperation` regardless of the value argument. A caller legitimately passing `nil` per the parent contract would be flagged by Steep as a type error on the subtype.
+The subclass drops the `?` on the second parameter, claiming nil is *not* accepted — but at runtime `Compressed#add`
+accepts anything and immediately raises `InvalidOperation` regardless of the value argument. A caller legitimately
+passing `nil` per the parent contract would be flagged by Steep as a type error on the subtype.
 
 This is a covariance violation: overriding methods must accept at least every argument the parent accepts.
 
@@ -255,9 +277,12 @@ def properties
 end
 ```
 
-Still unfixed. Two threads calling `Rambling::Trie.config` or `.create` concurrently can both observe `@properties` as `nil`, each call `Properties.new`, and the second write overwrites the first's instance (and any configuration applied to it).
+Still unfixed. Two threads calling `Rambling::Trie.config` or `.create` concurrently can both observe `@properties` as
+`nil`, each call `Properties.new`, and the second write overwrites the first's instance (and any configuration applied
+to it).
 
-**Fix:** Use a `Mutex`-guarded initializer or the `Monitor#synchronize` / `Concurrent::ReadWriteLock` pattern. Simplest fix:
+**Fix:** Use a `Mutex`-guarded initializer or the `Monitor#synchronize` / `Concurrent::ReadWriteLock` pattern. Simplest
+fix:
 
 ```ruby
 PROPERTIES_MUTEX = Mutex.new
@@ -274,7 +299,9 @@ end
 
 **File:** `lib/rambling/trie/nodes/node.rb:173-187`
 
-Still unfixed. Four abstract methods (`children_match_prefix`, `partial_word_chars?`, `word_chars?`, `closest_node`) raise `NotImplementedError` with no message. Also present on `readers/reader.rb:14` (`Reader#each_word`) and `serializers/serializer.rb:13,22` (`Serializer#load`, `Serializer#dump`).
+Still unfixed. Four abstract methods (`children_match_prefix`, `partial_word_chars?`, `word_chars?`, `closest_node`)
+raise `NotImplementedError` with no message. Also present on `readers/reader.rb:14` (`Reader#each_word`) and
+`serializers/serializer.rb:13,22` (`Serializer#load`, `Serializer#dump`).
 
 **Fix:**
 
@@ -308,9 +335,13 @@ attr_reader letter: Symbol?
 attr_accessor value: TValue?
 ```
 
-The concrete `Node#letter` is nullable (root node has `letter == nil`), and the mixin methods in the Ruby code explicitly handle `nil` (e.g. `Stringifyable#as_word` at `stringifyable.rb:11`: `if letter && !terminal?`, and `Inspectable#value_inspect` at `inspectable.rb:32`: `value && "value: #{value.inspect}"`).
+The concrete `Node#letter` is nullable (root node has `letter == nil`), and the mixin methods in the Ruby code
+explicitly handle `nil` (e.g. `Stringifyable#as_word` at `stringifyable.rb:11`: `if letter && !terminal?`, and
+`Inspectable#value_inspect` at `inspectable.rb:32`: `value && "value: #{value.inspect}"`).
 
-**Effect:** When Steep checks the mixin bodies against their abstract signatures, it infers `letter` is non-nullable and reports the `letter &&` guard as redundant — or fails to flag real `nil.frob` bugs when a new mixin method is added. Inside the mixin module it effectively disables the nil analysis.
+**Effect:** When Steep checks the mixin bodies against their abstract signatures, it infers `letter` is non-nullable and
+reports the `letter &&` guard as redundant — or fails to flag real `nil.frob` bugs when a new mixin method is added.
+Inside the mixin module it effectively disables the nil analysis.
 
 **Fix:** Change the abstract signatures to `Symbol?` and `TValue?`, matching the concrete attribute type.
 
@@ -334,7 +365,8 @@ def word? word = ''
 def scan word = ''
 ```
 
-So `trie.partial_word?` with no argument works in Ruby but fails Steep's arity check — a false-negative in the type layer for callers relying on the default.
+So `trie.partial_word?` with no argument works in Ruby but fails Steep's arity check — a false-negative in the type
+layer for callers relying on the default.
 
 **Fix:** Mark the argument optional in RBS:
 
@@ -355,7 +387,9 @@ class Missing < Rambling::Trie::Nodes::Node
 end
 ```
 
-`Missing` is a concrete class exposed via the public API (`scan` returns it for non-matching queries) but inherits from `Node` without overriding the four abstract private methods. Consequently, calling further methods that hit the abstract layer on a `Missing` result raises `NotImplementedError` from deep in the call stack:
+`Missing` is a concrete class exposed via the public API (`scan` returns it for non-matching queries) but inherits from
+`Node` without overriding the four abstract private methods. Consequently, calling further methods that hit the abstract
+layer on a `Missing` result raises `NotImplementedError` from deep in the call stack:
 
 ```ruby
 missing = trie.scan 'nonexistent'  # => Nodes::Missing
@@ -364,12 +398,15 @@ missing.word? %w(a b)              # => NotImplementedError (no message)
 missing.scan %w(a b)               # => NotImplementedError (no message)
 ```
 
-The public-facing `Enumerable#each` happens to work (terminal is `false`, children_tree is empty) so `missing.to_a == []` — but any char-based query crashes.
+The public-facing `Enumerable#each` happens to work (terminal is `false`, children_tree is empty) so `missing.to_a ==
+[]` — but any char-based query crashes.
 
-**Effect:** The `Missing` pattern is meant to be a null-object that silently answers "not found". Exposing half of it while the other half raises violates the pattern and leaks the abstract-method-private-ness to callers. Either:
+**Effect:** The `Missing` pattern is meant to be a null-object that silently answers "not found". Exposing half of it
+while the other half raises violates the pattern and leaks the abstract-method-private-ness to callers. Either:
 
 1. Implement the four abstract methods on `Missing` to return the empty/false result, or
-2. Override the public `partial_word?` / `word?` / `scan` methods on `Missing` directly to return `false` / `false` / `self`, or
+2. Override the public `partial_word?` / `word?` / `scan` methods on `Missing` directly to return `false` / `false` /
+  `self`, or
 3. Make `Missing` inherit from `Raw` or `Compressed` so the concrete overrides apply.
 
 ---
@@ -386,7 +423,9 @@ def contains? provider
 end
 ```
 
-Line 110 already returns when `provider` is nil. By line 112, `provider` is guaranteed non-nil, so `provider || raise` is dead code — the `raise` can never execute. The prior review's issue 19 flagged this (bundled with the `providers.any?` guard) and PR #107 removed the `providers.any?` check but left the `|| raise` tautology.
+Line 110 already returns when `provider` is nil. By line 112, `provider` is guaranteed non-nil, so `provider || raise`
+is dead code — the `raise` can never execute. The prior review's issue 19 flagged this (bundled with the
+`providers.any?` guard) and PR #107 removed the `providers.any?` check but left the `|| raise` tautology.
 
 **Fix:** Drop the `|| raise`:
 
@@ -398,7 +437,8 @@ def contains? provider
 end
 ```
 
-The `|| raise` was presumably added to satisfy Steep's unwrap-nil pattern, but the earlier `return true if provider.nil?` already narrows the type — Steep 1.9+ supports this narrowing.
+The `|| raise` was presumably added to satisfy Steep's unwrap-nil pattern, but the earlier `return true if
+provider.nil?` already narrows the type — Steep 1.9+ supports this narrowing.
 
 ---
 
@@ -427,11 +467,18 @@ The RBS contract (`container.rbs:63`) is:
 def words_within_root: (String) ?{ (String) -> void } -> Enumerator[String, void]
 ```
 
-When a block is given, the method's last expression is `0.upto(size - 1).each do …`. For a non-empty phrase, `.each` returns the `Range` (`0..size-1`), not an `Enumerator`. For an empty phrase, `0.upto(-1).each { … }` returns the empty range `0..-1`. In neither case does it return an `Enumerator[String, void]` as declared.
+When a block is given, the method's last expression is `0.upto(size - 1).each do …`. For a non-empty phrase, `.each`
+returns the `Range` (`0..size-1`), not an `Enumerator`. For an empty phrase, `0.upto(-1).each { … }` returns the empty
+range `0..-1`. In neither case does it return an `Enumerator[String, void]` as declared.
 
-Callers always immediately `.to_a` or `.any?` the result (`container.rb:115,123`), so this has never mattered at runtime — but the signature lies, and the `# : Enumerator[String, void]` comment-annotation on line 220 is Steep-telling-the-compiler-what-you-wish-was-true. The `# rubocop:disable Style/CommentedKeyword` is a direct consequence.
+Callers always immediately `.to_a` or `.any?` the result (`container.rb:115,123`), so this has never mattered at runtime
+— but the signature lies, and the `# : Enumerator[String, void]` comment-annotation on line 220 is
+Steep-telling-the-compiler-what-you-wish-was-true. The `# rubocop:disable Style/CommentedKeyword` is a direct
+consequence.
 
-**Fix:** Either return `self` (matches Ruby convention) and update the RBS, or explicitly return `enum_for :words_within_root, phrase` at the end even when a block was given (Ruby convention: yielding `each` returns the receiver or the enumerator). Cleanest:
+**Fix:** Either return `self` (matches Ruby convention) and update the RBS, or explicitly return `enum_for
+:words_within_root, phrase` at the end even when a block was given (Ruby convention: yielding `each` returns the
+receiver or the enumerator). Cleanest:
 
 ```ruby
 def words_within_root phrase
@@ -466,7 +513,9 @@ def compress
 end
 ```
 
-`compress` advertises a pure/non-mutating API by returning a new `Container` when it does work, but returns the *same* `Container` object when the root was already compressed. Callers cannot use `equal?` to detect which branch ran, and the contract differs from a "functional" `compress` in other data-structure gems.
+`compress` advertises a pure/non-mutating API by returning a new `Container` when it does work, but returns the *same*
+`Container` object when the root was already compressed. Callers cannot use `equal?` to detect which branch ran, and the
+contract differs from a "functional" `compress` in other data-structure gems.
 
 **Fix:** Always return a new `Container` wrapping the same (already-compressed) root:
 
@@ -490,9 +539,12 @@ def add _, _ = nil
 end
 ```
 
-Ruby permits repeating `_` as a parameter name (it's specifically exempted from the duplicate-parameter error), but it still reads as a typo. The style also hides the fact that the method takes two parameters — when skimming, most readers assume `add _` is a single-arg override.
+Ruby permits repeating `_` as a parameter name (it's specifically exempted from the duplicate-parameter error), but it
+still reads as a typo. The style also hides the fact that the method takes two parameters — when skimming, most readers
+assume `add _` is a single-arg override.
 
-**Fix:** Either use distinct names (`add _reversed_chars, _value = nil`) or rely on the parent's parameter names (re-declare with the same names, or use `...`):
+**Fix:** Either use distinct names (`add _reversed_chars, _value = nil`) or rely on the parent's parameter names
+(re-declare with the same names, or use `...`):
 
 ```ruby
 def add(...)
@@ -514,9 +566,12 @@ The `(...)` form matches the parent exactly and avoids the duplicate-underscore 
 - `lib/rambling/trie/nodes/compressed.rb:38,44,54,65,73,79,94,107`
 - `lib/rambling/trie/serializers/zip.rb:30,38,59`
 
-`raise` with no arguments in Ruby raises `RuntimeError` with a nil message. When any of these defensive assertions fire in production (e.g. `chars.first || raise` on an empty array), the bug report is a bare `RuntimeError` and the only signal is the backtrace line number.
+`raise` with no arguments in Ruby raises `RuntimeError` with a nil message. When any of these defensive assertions fire
+in production (e.g. `chars.first || raise` on an empty array), the bug report is a bare `RuntimeError` and the only
+signal is the backtrace line number.
 
-Most of these are Steep-appeasement unwraps where the fail case is genuinely "should never happen" — but when a *real* bug causes one to fire, the user is left to reverse-engineer which invariant was violated. A tiny message is free:
+Most of these are Steep-appeasement unwraps where the fail case is genuinely "should never happen" — but when a *real*
+bug causes one to fire, the user is left to reverse-engineer which invariant was violated. A tiny message is free:
 
 ```ruby
 letter = chars.first || raise('empty chars array')
@@ -528,7 +583,8 @@ Or better, raise a specific gem error so callers can rescue it:
 serializer || raise(ArgumentError, "no serializer could be resolved for #{filepath}")
 ```
 
-Not every bare `raise` deserves a full message — but the ones at public-API boundaries (`trie.rb`, `zip.rb:30,38`) benefit most.
+Not every bare `raise` deserves a full message — but the ones at public-API boundaries (`trie.rb`, `zip.rb:30,38`)
+benefit most.
 
 ---
 
@@ -544,11 +600,17 @@ def initialize letter = nil, parent = nil, children_tree = {}
 end
 ```
 
-The `= {}` default re-creates a fresh hash per call (Ruby semantics), which is correct. But the constructor accepts a caller-provided hash and stores it directly — it does not clone. Combined with issue 11 (`Compressed` mutating the caller's hash to reassign parents), this creates a subtle contract: *if you ever pass an existing hash, `Node`/`Compressed` takes ownership and may mutate it*.
+The `= {}` default re-creates a fresh hash per call (Ruby semantics), which is correct. But the constructor accepts a
+caller-provided hash and stores it directly — it does not clone. Combined with issue 11 (`Compressed` mutating the
+caller's hash to reassign parents), this creates a subtle contract: *if you ever pass an existing hash,
+`Node`/`Compressed` takes ownership and may mutate it*.
 
-This is documented nowhere, and the parameter is typed `Hash[Symbol, Node[TValue]]` with no annotation indicating the ownership transfer. New contributors or extenders would not expect the constructor to mutate arguments.
+This is documented nowhere, and the parameter is typed `Hash[Symbol, Node[TValue]]` with no annotation indicating the
+ownership transfer. New contributors or extenders would not expect the constructor to mutate arguments.
 
-**Fix:** Either document the ownership transfer explicitly in the YARD docs, or `.dup` the hash inside `Node#initialize` (cheap for typically-small hashes). If performance is a concern, document "ownership transferred" in the param docstring:
+**Fix:** Either document the ownership transfer explicitly in the YARD docs, or `.dup` the hash inside `Node#initialize`
+(cheap for typically-small hashes). If performance is a concern, document "ownership transferred" in the param
+docstring:
 
 ```ruby
 # @param [Hash<Symbol, Node>] children_tree the children tree. Ownership is

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -1,0 +1,567 @@
+# Code Review: `rambling-trie` v2.6.0
+
+Reviewed by Claude (claude-opus-4-7) on 2026-04-18.
+
+---
+
+## Summary Table
+
+Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicable
+
+| Done | #  | Severity     | File                                     | Issue                                                                        | PR or Feedback |
+|------|----|--------------|------------------------------------------|------------------------------------------------------------------------------|----------------|
+| [x]  | 31 | **Critical** | `nodes/compressed.rb:37-51`              | `partial_word_chars?` fall-through with mutated chars returns `true` for non-matching same-length prefixes | [#N][gh_N]     |
+| [x]  | 32 | **Critical** | `nodes/compressed.rb:72-87`              | `closest_node` has the same fall-through bug — `scan` returns wrong branch   | [#N][gh_N]     |
+| [ ]  | 11 | **High**     | `nodes/node.rb:42`, `nodes/compressed.rb:13-17` | Shared `children_tree` mutated via parent reassign in `Compressed` (carried from prior review) |                |
+| [ ]  | 33 | **High**     | `sig/lib/rambling/trie/container.rbs:20-21` | `Container#each` RBS overloads have the return types backwards               |                |
+| [ ]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` |                |
+| [ ]  | 35 | **High**     | `sig/lib/rambling/trie/nodes/compressed.rbs:7` | `Compressed#add` RBS signature is stricter than parent `Node#add` (contravariant-unsafe) |                |
+| [ ]  | 16 | **Medium**   | `trie.rb:77`                             | `@properties` lazy init is not thread-safe (carried from prior review)       |                |
+| [ ]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) |                |
+| [ ]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable |                |
+| [ ]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` |                |
+| [ ]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API |                |
+| [ ]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              |                |
+| [ ]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty |                |
+| [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
+| [ ]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     |                |
+| [ ]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message |                |
+| [ ]  | 43 | **Low**      | `lib/rambling/trie/nodes/node.rb:38-46`  | Default `children_tree = {}` arg creates fresh hash per call but signals shared-hash ownership with caller |                |
+
+---
+
+## Critical
+
+### 31. `Compressed#partial_word_chars?` returns `true` for non-matching same-length prefixes
+
+**File:** `lib/rambling/trie/nodes/compressed.rb:37-51`
+
+```ruby
+def partial_word_chars? chars
+  child = children_tree[(chars.first || raise).to_sym]
+  return false unless child
+
+  child_letter = child.letter.to_s
+
+  if chars.size >= child_letter.size
+    letter = (chars.shift(child_letter.size) || raise).join
+    return child.partial_word? chars if child_letter == letter
+  end
+
+  letter = chars.join
+  child_letter = child_letter.slice 0, letter.size
+  child_letter == letter
+end
+```
+
+When `chars.size >= child_letter.size` **and** the shifted prefix does not equal `child_letter`, the method falls through to the second check — but by that point `chars.shift(child_letter.size)` has already mutated `chars`. If `chars.size` was exactly equal to `child_letter.size`, `chars` is now empty, `letter = ''`, `child_letter.slice(0, 0) = ''`, and the method incorrectly returns `true`.
+
+**Reproduction:**
+
+```ruby
+trie = Rambling::Trie.create
+trie << 'hello'
+trie.compress!
+trie.partial_word? 'hallo'   # => true  (expected: false)
+trie.partial_word? 'hexyo'   # => true  (expected: false)
+trie.match? 'hallo'          # => true  (alias of partial_word?, same bug)
+```
+
+Also reproducible on any trie where a compressed child's letter length equals the query length and the first char matches but later chars diverge:
+
+```ruby
+trie = Rambling::Trie.create
+trie.concat %w(hello world)
+trie.compress!
+trie.partial_word? 'hallo'   # => true  (expected: false)
+trie.partial_word? 'wolld'   # => true  (expected: false)
+```
+
+**Root cause:** The `if` block mutates `chars` via `shift`, but the fall-through path uses the same mutated `chars` — it was designed for the `chars.size < child_letter.size` case where no shift happened.
+
+**Fix:** Make the two branches mutually exclusive, e.g.:
+
+```ruby
+if chars.size >= child_letter.size
+  letter = (chars.shift(child_letter.size) || raise).join
+  return false unless child_letter == letter
+  child.partial_word? chars
+else
+  letter = chars.join
+  child_letter.start_with?(letter)   # or slice/== as before
+end
+```
+
+This bug was not caught by the existing specs because `a_container_partial_word` tests only cover prefixes with `chars.size < child_letter.size` (`ha`, `hal`, `al`) and the integration tests use multi-child tries where the first char triggers a single-char compressed key (`:h`) that defers the match deeper.
+
+The same pattern exists in `match_child_prefix` (lines 100-112) but is correctly guarded there by `return empty_enum if chars.size < child_letter.size` — which returns early, avoiding the fall-through.
+
+---
+
+### 32. `Compressed#closest_node` returns wrong subtree for non-matching same-length prefixes
+
+**File:** `lib/rambling/trie/nodes/compressed.rb:72-87`
+
+```ruby
+def closest_node chars
+  child = children_tree[(chars.first || raise).to_sym]
+  return missing unless child
+
+  child_letter = child.letter.to_s
+
+  if chars.size >= child_letter.size
+    letter = (chars.shift(child_letter.size) || raise).join
+    return child.scan chars if child_letter == letter
+  end
+
+  letter = chars.join
+  child_letter = child_letter.slice 0, letter.size
+
+  child_letter == letter ? child : missing
+end
+```
+
+Identical structural bug to issue 31. When `chars.size == child_letter.size` and the shifted letter does not match, `chars` is emptied, `letter = ''` and `child_letter = ''`, so the method returns `child` instead of `missing`.
+
+**Reproduction:**
+
+```ruby
+trie = Rambling::Trie.create
+trie.concat %w(hello world)
+trie.compress!
+trie.scan 'hallo'      # => ["hello"]   (expected: [])
+trie.words 'hallo'     # => ["hello"]   (alias of scan, same bug)
+```
+
+**Fix:** Same structural change as issue 31 — make the branches mutually exclusive so the fall-through only runs when no shift occurred.
+
+---
+
+## High
+
+### 11. Shared `children_tree` hash mutated via parent reassignment in `Compressed` *(carried from prior review)*
+
+**File:** `lib/rambling/trie/nodes/node.rb:42`, `nodes/compressed.rb:13-18`
+
+`Compressed#initialize` forwards the caller's `children_tree` hash directly to `super` and then iterates it to set each child's `parent = self`. If the same hash object is ever shared with another node (e.g. constructing compressed nodes from existing subtrees), the parent reassignment silently rewires the other node's children.
+
+Still unfixed in the current HEAD:
+
+```ruby
+def initialize letter = nil, parent = nil, children_tree = {}
+  super
+  children_tree.each_value { |child| child.parent = self }
+end
+```
+
+**Fix:** Either dup the tree, or dup the children, in the `Compressed` constructor. The `Compressor` is the only internal caller and it already builds fresh trees — but the constructor itself is public and becomes a footgun for direct users.
+
+---
+
+### 33. `Container#each` RBS overloads have the block/no-block return types swapped
+
+**File:** `sig/lib/rambling/trie/container.rbs:20-21`
+
+```rbs
+def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable[TValue])
+          | -> Container[TValue]
+```
+
+The Ruby code (`container.rb:136-142`) is:
+
+```ruby
+def each
+  return enum_for :each unless block_given?     # no block   → Enumerator
+  root.each { |word| yield word }
+  self                                           # with block → Container (self)
+end
+```
+
+So:
+
+- **Block-given overload** should return `Container[TValue]` (returns `self`) — RBS says `Enumerator | Enumerable`.
+- **No-block overload** should return `Enumerator[String, void]` — RBS says `Container[TValue]`.
+
+They are inverted. Steep silently accepts the wrong inference in both directions, masking future regressions (including the `Container#each returns self` fix from PR #105).
+
+**Fix:**
+
+```rbs
+def each: { (String) -> void } -> Container[TValue]
+        | -> Enumerator[String, void]
+```
+
+The same "returns `self` (or `Enumerable[TValue]`) when block given" confusion exists on the module at `sig/lib/rambling/trie/enumerable.rbs:8`. Worth auditing together.
+
+---
+
+### 34. `Readers::PlainText#each_word` RBS yields `String?` but Ruby always yields `String`
+
+**File:** `sig/lib/rambling/trie/readers/plain_text.rbs:5`
+
+```rbs
+def each_word: (String) { (String?) -> void } -> (Enumerator[String?, void] | PlainText)
+```
+
+The Ruby code was fixed in PR #91 to use `line.chomp!` followed by `yield line` — so the yielded value is always a `String`. The nullable `String?` here is a leftover from the pre-fix signature (`yield line.chomp!` used to return `nil` when nothing was trimmed).
+
+**Effect:** Consumers like `Rambling::Trie.create` that type-check the block argument are forced to treat every word as possibly `nil` — defeating the point of the fix and silently propagating the old stale contract.
+
+**Fix:**
+
+```rbs
+def each_word: (String) { (String) -> void } -> (Enumerator[String, void] | PlainText)
+```
+
+Also affects the base `Reader` signature at `sig/lib/rambling/trie/readers/reader.rbs:5` (uses non-nullable `String`, so the subclass is *narrower* than the parent in the wrong direction — a contravariance issue on the block parameter).
+
+---
+
+### 35. `Compressed#add` RBS signature is stricter than parent `Node#add`
+
+**File:** `sig/lib/rambling/trie/nodes/compressed.rbs:7`
+
+```rbs
+def add: (Array[Symbol], ?TValue) -> Node[TValue]
+```
+
+Parent `Node#add` (`sig/lib/rambling/trie/nodes/raw.rbs:5` and `node.rbs:18`):
+
+```rbs
+def add: (Array[Symbol], ?TValue?) -> Node[TValue]
+```
+
+The subclass drops the `?` on the second parameter, claiming nil is *not* accepted — but at runtime `Compressed#add` accepts anything and immediately raises `InvalidOperation` regardless of the value argument. A caller legitimately passing `nil` per the parent contract would be flagged by Steep as a type error on the subtype.
+
+This is a covariance violation: overriding methods must accept at least every argument the parent accepts.
+
+**Fix:**
+
+```rbs
+def add: (Array[Symbol], ?TValue?) -> Node[TValue]
+```
+
+---
+
+## Medium
+
+### 16. `@properties` lazy initialization is not thread-safe *(carried from prior review)*
+
+**File:** `lib/rambling/trie.rb:76-78`
+
+```ruby
+def properties
+  @properties ||= Rambling::Trie::Configuration::Properties.new
+end
+```
+
+Still unfixed. Two threads calling `Rambling::Trie.config` or `.create` concurrently can both observe `@properties` as `nil`, each call `Properties.new`, and the second write overwrites the first's instance (and any configuration applied to it).
+
+**Fix:** Use a `Mutex`-guarded initializer or the `Monitor#synchronize` / `Concurrent::ReadWriteLock` pattern. Simplest fix:
+
+```ruby
+PROPERTIES_MUTEX = Mutex.new
+private_constant :PROPERTIES_MUTEX
+
+def properties
+  @properties || PROPERTIES_MUTEX.synchronize { @properties ||= Configuration::Properties.new }
+end
+```
+
+---
+
+### 18. Abstract methods raise bare `NotImplementedError` with no context *(carried from prior review)*
+
+**File:** `lib/rambling/trie/nodes/node.rb:173-187`
+
+Still unfixed. Four abstract methods (`children_match_prefix`, `partial_word_chars?`, `word_chars?`, `closest_node`) raise `NotImplementedError` with no message. Also present on `readers/reader.rb:14` (`Reader#each_word`) and `serializers/serializer.rb:13,22` (`Serializer#load`, `Serializer#dump`).
+
+**Fix:**
+
+```ruby
+raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+```
+
+Apply to every bare `raise NotImplementedError` in the gem.
+
+---
+
+### 36. Abstract `letter`/`value` methods typed as non-nullable but concrete `Node` is nullable
+
+**Files:**
+
+- `sig/lib/rambling/trie/comparable.rbs:10,12`
+- `sig/lib/rambling/trie/inspectable.rbs:23,25`
+- `sig/lib/rambling/trie/stringifyable.rbs:12`
+
+All three mixins declare:
+
+```rbs
+def letter: -> Symbol
+def value: -> TValue
+```
+
+But `Node` declares (`sig/lib/rambling/trie/nodes/node.rbs:11,14`):
+
+```rbs
+attr_reader letter: Symbol?
+attr_accessor value: TValue?
+```
+
+The concrete `Node#letter` is nullable (root node has `letter == nil`), and the mixin methods in the Ruby code explicitly handle `nil` (e.g. `Stringifyable#as_word` at `stringifyable.rb:11`: `if letter && !terminal?`, and `Inspectable#value_inspect` at `inspectable.rb:32`: `value && "value: #{value.inspect}"`).
+
+**Effect:** When Steep checks the mixin bodies against their abstract signatures, it infers `letter` is non-nullable and reports the `letter &&` guard as redundant — or fails to flag real `nil.frob` bugs when a new mixin method is added. Inside the mixin module it effectively disables the nil analysis.
+
+**Fix:** Change the abstract signatures to `Symbol?` and `TValue?`, matching the concrete attribute type.
+
+---
+
+### 37. `Container#partial_word?`, `#word?`, `#scan` RBS require `String` but Ruby defaults to `''`
+
+**File:** `sig/lib/rambling/trie/container.rbs:23,27,29`
+
+```rbs
+def partial_word?: (String) -> bool
+def word?: (String) -> bool
+def scan: (String) -> Array[String]
+```
+
+The Ruby definitions (`container.rb:78,98,106`) all default the argument to `''`:
+
+```ruby
+def partial_word? word = ''
+def word? word = ''
+def scan word = ''
+```
+
+So `trie.partial_word?` with no argument works in Ruby but fails Steep's arity check — a false-negative in the type layer for callers relying on the default.
+
+**Fix:** Mark the argument optional in RBS:
+
+```rbs
+def partial_word?: (?String) -> bool
+def word?: (?String) -> bool
+def scan: (?String) -> Array[String]
+```
+
+---
+
+### 38. `Nodes::Missing` inherits abstract `Node` methods that raise `NotImplementedError`
+
+**File:** `lib/rambling/trie/nodes/missing.rb`
+
+```ruby
+class Missing < Rambling::Trie::Nodes::Node
+end
+```
+
+`Missing` is a concrete class exposed via the public API (`scan` returns it for non-matching queries) but inherits from `Node` without overriding the four abstract private methods. Consequently, calling further methods that hit the abstract layer on a `Missing` result raises `NotImplementedError` from deep in the call stack:
+
+```ruby
+missing = trie.scan 'nonexistent'  # => Nodes::Missing
+missing.partial_word? %w(a b)      # => NotImplementedError (no message)
+missing.word? %w(a b)              # => NotImplementedError (no message)
+missing.scan %w(a b)               # => NotImplementedError (no message)
+```
+
+The public-facing `Enumerable#each` happens to work (terminal is `false`, children_tree is empty) so `missing.to_a == []` — but any char-based query crashes.
+
+**Effect:** The `Missing` pattern is meant to be a null-object that silently answers "not found". Exposing half of it while the other half raises violates the pattern and leaks the abstract-method-private-ness to callers. Either:
+
+1. Implement the four abstract methods on `Missing` to return the empty/false result, or
+2. Override the public `partial_word?` / `word?` / `scan` methods on `Missing` directly to return `false` / `false` / `self`, or
+3. Make `Missing` inherit from `Raw` or `Compressed` so the concrete overrides apply.
+
+---
+
+### 39. `ProviderCollection#contains?` still has dead `|| raise` after nil guard
+
+**File:** `lib/rambling/trie/configuration/provider_collection.rb:109-113`
+
+```ruby
+def contains? provider
+  return true if provider.nil?
+
+  provider_instances.include?(provider || raise)
+end
+```
+
+Line 110 already returns when `provider` is nil. By line 112, `provider` is guaranteed non-nil, so `provider || raise` is dead code — the `raise` can never execute. The prior review's issue 19 flagged this (bundled with the `providers.any?` guard) and PR #107 removed the `providers.any?` check but left the `|| raise` tautology.
+
+**Fix:** Drop the `|| raise`:
+
+```ruby
+def contains? provider
+  return true if provider.nil?
+
+  provider_instances.include? provider
+end
+```
+
+The `|| raise` was presumably added to satisfy Steep's unwrap-nil pattern, but the earlier `return true if provider.nil?` already narrows the type — Steep 1.9+ supports this narrowing.
+
+---
+
+### 40. `Container#words_within_root` returns wrong type when block given and phrase is empty
+
+**File:** `lib/rambling/trie/container.rb:211-222`
+
+```ruby
+def words_within_root phrase
+  return enum_for :words_within_root, phrase unless block_given?
+
+  chars = phrase.chars
+  size = chars.length
+  # rubocop:disable Style/CommentedKeyword
+  0.upto(size - 1).each do |starting_index|
+    new_phrase = chars.slice starting_index, size # : Array[String]
+    root.match_prefix(new_phrase) { |word| yield word }
+  end # : Enumerator[String, void]
+  # rubocop:enable Style/CommentedKeyword
+end
+```
+
+The RBS contract (`container.rbs:63`) is:
+
+```rbs
+def words_within_root: (String) ?{ (String) -> void } -> Enumerator[String, void]
+```
+
+When a block is given, the method's last expression is `0.upto(size - 1).each do …`. For a non-empty phrase, `.each` returns the `Range` (`0..size-1`), not an `Enumerator`. For an empty phrase, `0.upto(-1).each { … }` returns the empty range `0..-1`. In neither case does it return an `Enumerator[String, void]` as declared.
+
+Callers always immediately `.to_a` or `.any?` the result (`container.rb:115,123`), so this has never mattered at runtime — but the signature lies, and the `# : Enumerator[String, void]` comment-annotation on line 220 is Steep-telling-the-compiler-what-you-wish-was-true. The `# rubocop:disable Style/CommentedKeyword` is a direct consequence.
+
+**Fix:** Either return `self` (matches Ruby convention) and update the RBS, or explicitly return `enum_for :words_within_root, phrase` at the end even when a block was given (Ruby convention: yielding `each` returns the receiver or the enumerator). Cleanest:
+
+```ruby
+def words_within_root phrase
+  return enum_for :words_within_root, phrase unless block_given?
+
+  chars = phrase.chars
+  chars.each_index do |starting_index|
+    root.match_prefix(chars[starting_index..]) { |word| yield word }
+  end
+
+  self
+end
+```
+
+Then type the return as `Container[TValue] | Enumerator[String, void]`.
+
+---
+
+## Low
+
+### 30. `Container#compress` returns `self` when already compressed — inconsistent identity *(carried from prior review)*
+
+**File:** `lib/rambling/trie/container.rb:68-72`
+
+Still unfixed:
+
+```ruby
+def compress
+  return self if root.compressed?
+
+  Rambling::Trie::Container.new compress_root, compressor
+end
+```
+
+`compress` advertises a pure/non-mutating API by returning a new `Container` when it does work, but returns the *same* `Container` object when the root was already compressed. Callers cannot use `equal?` to detect which branch ran, and the contract differs from a "functional" `compress` in other data-structure gems.
+
+**Fix:** Always return a new `Container` wrapping the same (already-compressed) root:
+
+```ruby
+def compress
+  return Rambling::Trie::Container.new(root, compressor) if root.compressed?
+
+  Rambling::Trie::Container.new compress_root, compressor
+end
+```
+
+---
+
+### 41. `Compressed#add` uses duplicate `_` parameter names
+
+**File:** `lib/rambling/trie/nodes/compressed.rb:25`
+
+```ruby
+def add _, _ = nil
+  raise Rambling::Trie::InvalidOperation, 'Cannot add word to compressed trie'
+end
+```
+
+Ruby permits repeating `_` as a parameter name (it's specifically exempted from the duplicate-parameter error), but it still reads as a typo. The style also hides the fact that the method takes two parameters — when skimming, most readers assume `add _` is a single-arg override.
+
+**Fix:** Either use distinct names (`add _reversed_chars, _value = nil`) or rely on the parent's parameter names (re-declare with the same names, or use `...`):
+
+```ruby
+def add(...)
+  raise InvalidOperation, 'Cannot add word to compressed trie'
+end
+```
+
+The `(...)` form matches the parent exactly and avoids the duplicate-underscore smell.
+
+---
+
+### 42. Bare `|| raise` produces uninformative `RuntimeError` with no message
+
+**Files:** many — non-exhaustive list:
+
+- `lib/rambling/trie.rb:46,63` — serializer resolution
+- `lib/rambling/trie/container.rb:225` — `compress_root`
+- `lib/rambling/trie/nodes/raw.rb:34,47,55,63,75`
+- `lib/rambling/trie/nodes/compressed.rb:38,44,54,65,73,79,94,107`
+- `lib/rambling/trie/serializers/zip.rb:30,38,59`
+
+`raise` with no arguments in Ruby raises `RuntimeError` with a nil message. When any of these defensive assertions fire in production (e.g. `chars.first || raise` on an empty array), the bug report is a bare `RuntimeError` and the only signal is the backtrace line number.
+
+Most of these are Steep-appeasement unwraps where the fail case is genuinely "should never happen" — but when a *real* bug causes one to fire, the user is left to reverse-engineer which invariant was violated. A tiny message is free:
+
+```ruby
+letter = chars.first || raise('empty chars array')
+```
+
+Or better, raise a specific gem error so callers can rescue it:
+
+```ruby
+serializer || raise(ArgumentError, "no serializer could be resolved for #{filepath}")
+```
+
+Not every bare `raise` deserves a full message — but the ones at public-API boundaries (`trie.rb`, `zip.rb:30,38`) benefit most.
+
+---
+
+### 43. `Node#initialize` default `children_tree = {}` signals shared-hash ownership
+
+**File:** `lib/rambling/trie/nodes/node.rb:38-46`
+
+```ruby
+def initialize letter = nil, parent = nil, children_tree = {}
+  @letter = letter
+  @parent = parent
+  @children_tree = children_tree
+end
+```
+
+The `= {}` default re-creates a fresh hash per call (Ruby semantics), which is correct. But the constructor accepts a caller-provided hash and stores it directly — it does not clone. Combined with issue 11 (`Compressed` mutating the caller's hash to reassign parents), this creates a subtle contract: *if you ever pass an existing hash, `Node`/`Compressed` takes ownership and may mutate it*.
+
+This is documented nowhere, and the parameter is typed `Hash[Symbol, Node[TValue]]` with no annotation indicating the ownership transfer. New contributors or extenders would not expect the constructor to mutate arguments.
+
+**Fix:** Either document the ownership transfer explicitly in the YARD docs, or `.dup` the hash inside `Node#initialize` (cheap for typically-small hashes). If performance is a concern, document "ownership transferred" in the param docstring:
+
+```ruby
+# @param [Hash<Symbol, Node>] children_tree the children tree. Ownership is
+#   transferred to this node; callers must not retain or mutate the hash.
+```
+
+---
+
+[fb_6]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-6
+[fb_10]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-10
+[fb_13]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-13
+[fb_15]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-15
+[fb_23]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-23
+[fb_24]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-24
+[fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
+[gh_user_gonzedge]: https://github.com/gonzedge

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -10,8 +10,8 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 
 | Done | #  | Severity     | File                                     | Issue                                                                        | PR or Feedback |
 |------|----|--------------|------------------------------------------|------------------------------------------------------------------------------|----------------|
-| [x]  | 31 | **Critical** | `nodes/compressed.rb:37-51`              | `partial_word_chars?` fall-through with mutated chars returns `true` for non-matching same-length prefixes | [#N][gh_N]     |
-| [x]  | 32 | **Critical** | `nodes/compressed.rb:72-87`              | `closest_node` has the same fall-through bug — `scan` returns wrong branch   | [#N][gh_N]     |
+| [x]  | 31 | **Critical** | `nodes/compressed.rb:37-51`              | `partial_word_chars?` fall-through with mutated chars returns `true` for non-matching same-length prefixes | [#109][gh_109]     |
+| [x]  | 32 | **Critical** | `nodes/compressed.rb:72-87`              | `closest_node` has the same fall-through bug — `scan` returns wrong branch   | [#109][gh_109]     |
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`, `nodes/compressed.rb:13-17` | Shared `children_tree` mutated via parent reassign in `Compressed` (carried from prior review) |                |
 | [ ]  | 33 | **High**     | `sig/lib/rambling/trie/container.rbs:20-21` | `Container#each` RBS overloads have the return types backwards               |                |
 | [ ]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` |                |
@@ -626,4 +626,5 @@ docstring:
 [fb_23]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-23
 [fb_24]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-24
 [fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
+[gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -70,19 +70,19 @@ module Rambling
         end
 
         def closest_node chars
-          child = children_tree[(chars.first || raise('empty chars in closest_node')).to_sym]
+          child = children_tree[(chars.first || raise).to_sym]
           return missing unless child
 
           child_letter = child.letter.to_s
 
-          if chars.size >= child_letter.size
-            letter = (chars.shift(child_letter.size) || raise('shift returned nil in closest_node')).join
-            return missing unless child_letter == letter
-
-            child.scan chars
-          else
-            child_letter.start_with?(chars.join) ? child : missing
+          if chars.size < child_letter.size
+            return child_letter.start_with?(chars.join) ? child : missing
           end
+
+          letter = (chars.shift(child_letter.size) || raise).join
+          return missing unless child_letter == letter
+
+          child.scan chars
         end
 
         def children_match_prefix chars

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -35,19 +35,19 @@ module Rambling
         private
 
         def partial_word_chars? chars
-          child = children_tree[(chars.first || raise).to_sym]
+          child = children_tree[(chars.first || raise('empty chars in partial_word_chars?')).to_sym]
           return false unless child
 
           child_letter = child.letter.to_s
 
           if chars.size >= child_letter.size
-            letter = (chars.shift(child_letter.size) || raise).join
-            return child.partial_word? chars if child_letter == letter
-          end
+            letter = (chars.shift(child_letter.size) || raise('shift returned nil in partial_word_chars?')).join
+            return false unless child_letter == letter
 
-          letter = chars.join
-          child_letter = child_letter.slice 0, letter.size
-          child_letter == letter
+            child.partial_word? chars
+          else
+            child_letter.start_with? chars.join
+          end
         end
 
         def word_chars? chars
@@ -70,20 +70,19 @@ module Rambling
         end
 
         def closest_node chars
-          child = children_tree[(chars.first || raise).to_sym]
+          child = children_tree[(chars.first || raise('empty chars in closest_node')).to_sym]
           return missing unless child
 
           child_letter = child.letter.to_s
 
           if chars.size >= child_letter.size
-            letter = (chars.shift(child_letter.size) || raise).join
-            return child.scan chars if child_letter == letter
+            letter = (chars.shift(child_letter.size) || raise('shift returned nil in closest_node')).join
+            return missing unless child_letter == letter
+
+            child.scan chars
+          else
+            child_letter.start_with?(chars.join) ? child : missing
           end
-
-          letter = chars.join
-          child_letter = child_letter.slice 0, letter.size
-
-          child_letter == letter ? child : missing
         end
 
         def children_match_prefix chars

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -306,6 +306,24 @@ describe Rambling::Trie::Container do
         end
       end
     end
+
+    context 'when query shares only first char with a contained same-length word' do
+      before { add_words container, %w(hello world) }
+
+      it 'returns an empty array for a diverging same-length query' do
+        expect(container.scan 'hallo').to eq %w()
+        expect(container.scan 'wolld').to eq %w()
+      end
+
+      context 'with compressed root' do
+        before { container.compress! }
+
+        it 'returns an empty array for a diverging same-length query after compression' do
+          expect(container.scan 'hallo').to eq %w()
+          expect(container.scan 'wolld').to eq %w()
+        end
+      end
+    end
   end
 
   describe '#words_within' do

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -310,6 +310,7 @@ describe Rambling::Trie::Container do
     context 'when query shares only first char with a contained same-length word' do
       before { add_words container, %w(hello world) }
 
+      # rubocop:disable RSpec/MultipleExpectations
       it 'returns an empty array for a diverging same-length query' do
         expect(container.scan 'hallo').to eq %w()
         expect(container.scan 'wolld').to eq %w()
@@ -323,6 +324,7 @@ describe Rambling::Trie::Container do
           expect(container.scan 'wolld').to eq %w()
         end
       end
+      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 

--- a/spec/support/shared_examples/a_container_partial_word.rb
+++ b/spec/support/shared_examples/a_container_partial_word.rb
@@ -14,4 +14,10 @@ shared_examples_for 'a non-matching container#partial_word' do
       expect(container.partial_word? word).to be false
     end
   end
+
+  it 'does not match a same-length prefix that differs in middle characters' do
+    %w(hallo hexyo).each do |word|
+      expect(container.partial_word? word).to be false
+    end
+  end
 end


### PR DESCRIPTION
_Deals with issues 31 and 32 in [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

Currently, `partial_word_chars?` and `closest_node` both shifted `chars` inside the `chars.size >= child_letter.size` branch and then fell through to the short-prefix comparison with a mutated (often empty) array - making a diverging same length prefix like `hallo` match `hello`.

This PR explicitly splits the branches so that the shift path returns immediately on mismatch and the short-prefix path only runs when no shift occurred. It also adds regression specs for both `partial_word?` / `scan` (and their aliases) for these diverging same-length queries, both before and after compression.