### PR TITLE
Implement method overrides so `Nodes::Missing` is a proper null object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
   - Make the `chars.size >= child_letter.size` branch mutually exclusive with the short-prefix branch; the shift mutates
     `chars`, so fall-through was incorrectly passing an empty `chars` to the second comparison
   - Add regression specs for `partial_word?`/`scan` on diverging same-length queries like `hallo`/`wolld`
+- Implement `Nodes::Missing` as a proper null object ([#110][github_pull_110]) by [@gonzedge][github_user_gonzedge]
+  - Override `partial_word?`, `word_chars?`, `closest_node`, and `children_match_prefix` to return safe empty results
+    instead of raising `NotImplementedError`
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1374,6 +1377,7 @@ Most of these help with the gem's overall performance.
 [github_pull_107]: https://github.com/gonzedge/rambling-trie/pull/107
 [github_pull_108]: https://github.com/gonzedge/rambling-trie/pull/108
 [github_pull_109]: https://github.com/gonzedge/rambling-trie/pull/109
+[github_pull_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -20,7 +20,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) |                |
 | [ ]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable |                |
 | [ ]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` |                |
-| [ ]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API |                |
+| [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
 | [ ]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              |                |
 | [ ]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty |                |
 | [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
@@ -627,4 +627,5 @@ docstring:
 [fb_24]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-24
 [fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
 [gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
+[gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/nodes/missing.rb
+++ b/lib/rambling/trie/nodes/missing.rb
@@ -5,22 +5,22 @@ module Rambling
     module Nodes
       # A representation of a missing node in the trie data structure. Returned when a node is not found.
       class Missing < Rambling::Trie::Nodes::Node
-        def partial_word? _chars
+        def partial_word? _
           false
         end
 
         private
 
-        def word_chars? _chars
+        def word_chars? _
           false
         end
 
-        def closest_node _chars
+        def closest_node _
           self
         end
 
-        def children_match_prefix _chars
-          return enum_for :children_match_prefix, _chars unless block_given?
+        def children_match_prefix chars
+          enum_for :children_match_prefix, chars unless block_given?
         end
       end
     end

--- a/lib/rambling/trie/nodes/missing.rb
+++ b/lib/rambling/trie/nodes/missing.rb
@@ -5,6 +5,23 @@ module Rambling
     module Nodes
       # A representation of a missing node in the trie data structure. Returned when a node is not found.
       class Missing < Rambling::Trie::Nodes::Node
+        def partial_word? _chars
+          false
+        end
+
+        private
+
+        def word_chars? _chars
+          false
+        end
+
+        def closest_node _chars
+          self
+        end
+
+        def children_match_prefix _chars
+          return enum_for :children_match_prefix, _chars unless block_given?
+        end
       end
     end
   end

--- a/sig/lib/rambling/trie/nodes/missing.rbs
+++ b/sig/lib/rambling/trie/nodes/missing.rbs
@@ -3,6 +3,14 @@ module Rambling
     module Nodes
       class Missing[TValue < BasicObject & _Inspect & _Nilable] < Node[TValue]
         def initialize: -> void
+        def partial_word?: (Array[String] chars) -> bool
+
+        private
+
+        def word_chars?: (Array[String] chars) -> bool
+        def closest_node: (Array[String] chars) -> Node[TValue]
+        def children_match_prefix: (Array[String] chars) -> void
+                                 | (Array[String] chars) { (String word) -> void } -> void
       end
     end
   end

--- a/spec/lib/rambling/trie/nodes/missing_spec.rb
+++ b/spec/lib/rambling/trie/nodes/missing_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Rambling::Trie::Nodes::Missing do
+  let(:node) { described_class.new }
+
+  %i(partial_word? word?).each do |method|
+    describe "##{method}" do
+      it 'returns false for any chars' do
+        expect(node.send(method, %w(a b))).to be false
+      end
+
+      it 'returns false for empty chars' do
+        expect(node.send(method, [])).to be false
+      end
+    end
+  end
+
+  describe '#each' do
+    it 'yields nothing' do
+      expect(node.to_a).to be_empty
+    end
+  end
+end

--- a/spec/lib/rambling/trie/nodes/missing_spec.rb
+++ b/spec/lib/rambling/trie/nodes/missing_spec.rb
@@ -17,6 +17,12 @@ describe Rambling::Trie::Nodes::Missing do
     end
   end
 
+  describe '#match_prefix' do
+    it 'returns nothing' do
+      expect(node.match_prefix(%(a b)).to_a).to be_empty
+    end
+  end
+
   describe '#each' do
     it 'yields nothing' do
       expect(node.to_a).to be_empty


### PR DESCRIPTION
_Deals with issue 38 from [doc/20260418-claude-code-review.md](https://github.com/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)_.

`Nodes::Missing` is meant to be the null object returned by `scan` when no match is found. Currently though, it simply inherits abstract `Node` private methods that raise `NotImplementedError`. Any caller that continued to call `partial_word?`, `word?`, or `scan` on the result would get a confusing error.

This PR:

- Overrides `partial_word?` to always return `false`
- Overrides `word_chars?` to return `false` for any chars
- Overrides `closest_node` to return `self`, making `scan` on a `Missing` node return itself
- Overrides `children_match_prefix` to yield nothing
- Updates RBS signature for `Nodes::Missing` to declare all four overrides
- Adds full test coverage for the null-object contract