### PR TITLE
Improve many RBS signatures and return `self` from `Container#words_within_root` with block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@
 - Implement `Nodes::Missing` as a proper null object ([#110][github_pull_110]) by [@gonzedge][github_user_gonzedge]
   - Override `partial_word?`, `word_chars?`, `closest_node`, and `children_match_prefix` to return safe empty results
     instead of raising `NotImplementedError`
+- Return `self` from `Container#words_within_root` with block and correct RBS signatures ([#111][github_pull_111])
+  by [@gonzedge][github_user_gonzedge]
+  - Switch `words_within_root` from `0.upto(size-1).each` to `each_index`, return `self` explicitly; update RBS to
+    `Container[TValue] | Enumerator[String, void]`
+  - Swap `Container#each` / `Enumerable#each` block/no-block overloads - block returns `self`, no-block returns
+    `Enumerator` (regression from #105)
+  - Tighten `Readers::PlainText#each_word` block arg from `String?` to `String` (non-nullable since #91)
+  - Widen `Nodes::Compressed#add` second arg to `?TValue?` to match parent `Nodes::Node#add` contract
+  - Mark `letter`/`value` abstract signatures nullable in `Comparable`, `Inspectable`, `Stringifyable` mixins
+  - Mark `Container#{partial_word?,word?,scan}` args optional to match `''` Ruby defaults
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1378,6 +1388,7 @@ Most of these help with the gem's overall performance.
 [github_pull_108]: https://github.com/gonzedge/rambling-trie/pull/108
 [github_pull_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [github_pull_110]: https://github.com/gonzedge/rambling-trie/pull/110
+[github_pull_111]: https://github.com/gonzedge/rambling-trie/pull/111
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -13,13 +13,13 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 31 | **Critical** | `nodes/compressed.rb:37-51`              | `partial_word_chars?` fall-through with mutated chars returns `true` for non-matching same-length prefixes | [#109][gh_109]     |
 | [x]  | 32 | **Critical** | `nodes/compressed.rb:72-87`              | `closest_node` has the same fall-through bug — `scan` returns wrong branch   | [#109][gh_109]     |
 | [ ]  | 11 | **High**     | `nodes/node.rb:42`, `nodes/compressed.rb:13-17` | Shared `children_tree` mutated via parent reassign in `Compressed` (carried from prior review) |                |
-| [ ]  | 33 | **High**     | `sig/lib/rambling/trie/container.rbs:20-21` | `Container#each` RBS overloads have the return types backwards               |                |
-| [ ]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` |                |
-| [ ]  | 35 | **High**     | `sig/lib/rambling/trie/nodes/compressed.rbs:7` | `Compressed#add` RBS signature is stricter than parent `Node#add` (contravariant-unsafe) |                |
+| [x]  | 33 | **High**     | `sig/lib/rambling/trie/container.rbs:20-21` | `Container#each` RBS overloads have the return types backwards               | [#111][gh_111] |
+| [x]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` | [#111][gh_111] |
+| [x]  | 35 | **High**     | `sig/lib/rambling/trie/nodes/compressed.rbs:7` | `Compressed#add` RBS signature is stricter than parent `Node#add` (contravariant-unsafe) | [#111][gh_111] |
 | [ ]  | 16 | **Medium**   | `trie.rb:77`                             | `@properties` lazy init is not thread-safe (carried from prior review)       |                |
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) |                |
-| [ ]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable |                |
-| [ ]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` |                |
+| [x]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable | [#111][gh_111] |
+| [x]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` | [#111][gh_111] |
 | [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
 | [ ]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              |                |
 | [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -22,7 +22,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [ ]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` |                |
 | [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
 | [ ]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              |                |
-| [ ]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty |                |
+| [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |
 | [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
 | [ ]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     |                |
 | [ ]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message |                |
@@ -628,4 +628,5 @@ docstring:
 [fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
 [gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
+[gh_111]: https://github.com/gonzedge/rambling-trie/pull/111
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -212,13 +212,12 @@ module Rambling
         return enum_for :words_within_root, phrase unless block_given?
 
         chars = phrase.chars
-        size = chars.length
-        # rubocop:disable Style/CommentedKeyword
-        0.upto(size - 1).each do |starting_index|
-          new_phrase = chars.slice starting_index, size # : Array[String]
+        chars.each_index do |starting_index|
+          new_phrase = chars[starting_index..] || raise('slice returned nil in words_within_root')
           root.match_prefix(new_phrase) { |word| yield word }
-        end # : Enumerator[String, void]
-        # rubocop:enable Style/CommentedKeyword
+        end
+
+        self
       end
 
       def compress_root

--- a/sig/lib/rambling/trie/comparable.rbs
+++ b/sig/lib/rambling/trie/comparable.rbs
@@ -7,9 +7,9 @@ module Rambling
 
       # abstract methods
 
-      def letter: -> Symbol
+      def letter: -> Symbol?
 
-      def value: -> TValue
+      def value: -> TValue?
 
       def terminal?: -> bool
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -60,7 +60,7 @@ module Rambling
       attr_reader compressor: Compressor[TValue]
       attr_writer root: Nodes::Node[TValue]
 
-      def words_within_root: (String) ?{ (String) -> void } -> Enumerator[String, void]
+      def words_within_root: (String) ?{ (String) -> void } -> (Container[TValue] | Enumerator[String, void])
 
       def compress_root: -> Nodes::Compressed[TValue]
 

--- a/sig/lib/rambling/trie/container.rbs
+++ b/sig/lib/rambling/trie/container.rbs
@@ -17,16 +17,16 @@ module Rambling
 
       def compress: -> Container[TValue]
 
-      def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable[TValue])
-                | -> Container[TValue]
+      def each: { (String) -> void } -> Container[TValue]
+                | -> Enumerator[String, void]
 
-      def partial_word?: (String) -> bool
+      def partial_word?: (?String) -> bool
 
       def push: (*String) -> Array[Nodes::Node[TValue]]
 
-      def word?: (String) -> bool
+      def word?: (?String) -> bool
 
-      def scan: (String) -> Array[String]
+      def scan: (?String) -> Array[String]
 
       def words_within: (String) -> Array[String]
 

--- a/sig/lib/rambling/trie/enumerable.rbs
+++ b/sig/lib/rambling/trie/enumerable.rbs
@@ -5,7 +5,8 @@ module Rambling
 
       alias size count
 
-      def each: { (String) -> void } -> (Enumerator[String, void] | Enumerable[TValue])
+      def each: { (String) -> void } -> Enumerable[TValue]
+                | -> Enumerator[String, void]
 
       private
 

--- a/sig/lib/rambling/trie/inspectable.rbs
+++ b/sig/lib/rambling/trie/inspectable.rbs
@@ -20,9 +20,9 @@ module Rambling
 
       # abstract methods
 
-      def letter: -> Symbol
+      def letter: -> Symbol?
 
-      def value: -> TValue
+      def value: -> TValue?
 
       def terminal: -> bool?
 

--- a/sig/lib/rambling/trie/nodes/compressed.rbs
+++ b/sig/lib/rambling/trie/nodes/compressed.rbs
@@ -4,7 +4,7 @@ module Rambling
       class Compressed[TValue < BasicObject & _Inspect & _Nilable] < Node[TValue]
         def initialize: (?Symbol?, ?Node[TValue]?, ?Hash[Symbol, Node[TValue]]) -> void
 
-        def add: (Array[Symbol], ?TValue) -> Node[TValue]
+        def add: (Array[Symbol], ?TValue?) -> Node[TValue]
 
         def compressed?: -> bool
 

--- a/sig/lib/rambling/trie/readers/plain_text.rbs
+++ b/sig/lib/rambling/trie/readers/plain_text.rbs
@@ -2,7 +2,7 @@ module Rambling
   module Trie
     module Readers
       class PlainText < Reader
-        def each_word: (String) { (String?) -> void } -> (Enumerator[String?, void] | PlainText)
+        def each_word: (String) { (String) -> void } -> (Enumerator[String, void] | PlainText)
       end
     end
   end

--- a/sig/lib/rambling/trie/stringifyable.rbs
+++ b/sig/lib/rambling/trie/stringifyable.rbs
@@ -9,7 +9,7 @@ module Rambling
 
       # abstract methods
 
-      def letter: -> Symbol
+      def letter: -> Symbol?
 
       def terminal?: -> bool
 


### PR DESCRIPTION
_Deals with issues 33, 34, 35, 36, 37 and 40 from [doc/20260418-claude-code-review.md](https://github.com/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

Currently, issue 40 in the code review doc says that, when a block is given, `words_within_root` returns the `Range` produced by `0.upto(size-1).each`, which is the wrong type and wrong Ruby-convention contract, since having an empty phrase will make `0.upto(-1).each` return `0..-1` instead of the `Container`.

Additionally, there's a few type inconsistencies that can be tightened or be expressed more accurately.

This PR:

- Issue 40
  - Updates the `words_within_root` RBS signature to `Container[TValue] | Enumerator[String, void]`
  - Switches implementation to `each_index` and return `self` explicitly
  - Drops the now-unnecessary rubocop `Style/CommentedKeyword` disable
  - Drops the now-unnecessary `# : Enumerator` annotation
- Issue 33
  - Fixes `Container#each` and `Enumerable#each` type signature overload issues (swap block and no-block)
  - Regression was introduced in #105
- Issue 34
  - Changes `Readers::PlainText#each_word` block arg `String{?,}`
  - Runtime is yielding only `String` since fix in #91
- Issue 35
  - Changes `Nodes::Compressed#add` second arg `TValue{,?}` due to contravariance unsafety
- Issue 36
  - Updates `letter`/`value` signatures in `Comparable`, `Inspectable`, and `Stringifyable` to handle `nil`
- Issue 37
  - Mark `Container#{partial_word?,word?,scan}` arg `{,?}String` as optional