### PR TITLE
Make `Rambling::Trie.properties` init thread-safe 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
     `Dockerfile.benchmark`
   - Output files named `tmp/<version>@<ruby_version>.benchmark`; diffs saved as `tmp/<spec1>-vs-<spec2>.benchmark.diff`
   - Diff formatted with `git diff --no-index` for familiar colored output
+- Make `Rambling::Trie.properties` init thread-safe ([#113][github_pull_113]) by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1397,6 +1398,7 @@ Most of these help with the gem's overall performance.
 [github_pull_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [github_pull_111]: https://github.com/gonzedge/rambling-trie/pull/111
 [github_pull_112]: https://github.com/gonzedge/rambling-trie/pull/112
+[github_pull_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -25,7 +25,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [-]  | 13 | **Medium**   | `stringifyable.rb:22`            | `to_s` has O(depth²) string allocations                            | [feedback][fb_13], [#100][gh_100] |
 | [x]  | 14 | **Medium**   | `nodes/node.rb:59`               | `first_child` disables RuboCop to exploit loop-break trick         | [#102][gh_102]                    |
 | [-]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`              | [feedback][fb_15]                 |
-| [ ]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                         |                                   |
+| [x]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                         | [#113][gh_113]                    |
 | [x]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations       | [#106][gh_106]                    |
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context  |                                   |
 | [x]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections       | [#107][gh_107]                    |
@@ -736,4 +736,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_106]: https://github.com/gonzedge/rambling-trie/pull/106
 [gh_107]: https://github.com/gonzedge/rambling-trie/pull/107
 [gh_108]: https://github.com/gonzedge/rambling-trie/pull/108
+[gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -16,7 +16,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 33 | **High**     | `sig/lib/rambling/trie/container.rbs:20-21` | `Container#each` RBS overloads have the return types backwards               | [#111][gh_111] |
 | [x]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` | [#111][gh_111] |
 | [x]  | 35 | **High**     | `sig/lib/rambling/trie/nodes/compressed.rbs:7` | `Compressed#add` RBS signature is stricter than parent `Node#add` (contravariant-unsafe) | [#111][gh_111] |
-| [ ]  | 16 | **Medium**   | `trie.rb:77`                             | `@properties` lazy init is not thread-safe (carried from prior review)       |                |
+| [x]  | 16 | **Medium**   | `trie.rb:77`                             | `@properties` lazy init is not thread-safe (carried from prior review)       | [#113][gh_113] |
 | [ ]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) |                |
 | [x]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable | [#111][gh_111] |
 | [x]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` | [#111][gh_111] |
@@ -659,4 +659,5 @@ docstring:
 [gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [gh_111]: https://github.com/gonzedge/rambling-trie/pull/111
+[gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -10,6 +10,9 @@ path = File.join 'rambling', 'trie'
 module Rambling
   # Entry point for `rambling-trie` API.
   module Trie
+    PROPERTIES_MUTEX = Mutex.new
+    private_constant :PROPERTIES_MUTEX
+
     class << self
       # Creates a new `Rambling::Trie`. Entry point for the `rambling-trie` API.
       # @param [String, nil] filepath the file to load the words from.
@@ -74,7 +77,11 @@ module Rambling
       private
 
       def properties
-        @properties ||= Rambling::Trie::Configuration::Properties.new
+        return @properties if @properties
+
+        PROPERTIES_MUTEX.synchronize do
+          @properties ||= Rambling::Trie::Configuration::Properties.new
+        end
       end
 
       def readers

--- a/sig/lib/rambling/trie.rbs
+++ b/sig/lib/rambling/trie.rbs
@@ -12,6 +12,8 @@ module Rambling
 
     private
 
+    PROPERTIES_MUTEX: Mutex
+
     def self.properties: [TValue < BasicObject & _Inspect & _Nilable] -> Configuration::Properties[TValue]
 
     def self.readers: -> Configuration::ProviderCollection[Readers::Reader]

--- a/spec/lib/rambling/trie_spec.rb
+++ b/spec/lib/rambling/trie_spec.rb
@@ -241,4 +241,14 @@ describe Rambling::Trie do
       expect(yielded).to eq described_class.send :properties
     end
   end
+
+  describe '.properties' do
+    it 'returns the same object across concurrent calls' do
+      results = Array.new(10) do
+        Thread.new { described_class.send :properties }
+      end.map(&:value)
+
+      expect(results.uniq.size).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
_Deals with issue no. 16 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md) [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

Two threads calling `Rambling::Trie.config` simultaneously could each observe `@properties` as `nil`, both instantiate `Properties`, and the second write would silently discard the first's initialization and any configuration applied.

This PR adds a `PROPERTIES_MUTEX` private constant to use it for a double-checked lock in `Rambling::Trie.properties`, making the lazy init thread-safe.