### PR TITLE
Extract `NotImplemented` mixin; add descriptive abstract method error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@
   - Output files named `tmp/<version>@<ruby_version>.benchmark`; diffs saved as `tmp/<spec1>-vs-<spec2>.benchmark.diff`
   - Diff formatted with `git diff --no-index` for familiar colored output
 - Make `Rambling::Trie.properties` init thread-safe ([#113][github_pull_113]) by [@gonzedge][github_user_gonzedge]
+- Extract `NotImplemented` mixin; add descriptive abstract method error messages ([#114][github_pull_114])
+  by [@gonzedge][github_user_gonzedge]
+  - Introduces `Rambling::Trie::NotImplemented`, a private mixin that provides a single `not_implemented` helper used by
+    all abstract method stubs to raise `NotImplementedError` with the concrete class name and calling method name via
+    `caller_locations`
+  - Replaces all bare `raise NotImplementedError` in `Node`, `Reader`, and `Serializer`
+  - Adds `@raise [NotImplementedError]` to all abstract method docstrings
+  - Adds corresponding type signature with `-> bot` and `module NotImplemented : ::Object` tricks to make the definition
+    more flexible
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -27,7 +27,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [-]  | 15 | **Medium**   | `comparable.rb`, `enumerable.rb` | Module names shadow `::Comparable` and `::Enumerable`              | [feedback][fb_15]                 |
 | [x]  | 16 | **Medium**   | `trie.rb:79`                     | `@properties` lazy init is not thread-safe                         | [#113][gh_113]                    |
 | [x]  | 17 | **Medium**   | `container.rb:220`               | Unnecessary `.to_a` no-op and three intermediate allocations       | [#106][gh_106]                    |
-| [ ]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context  |                                   |
+| [x]  | 18 | **Medium**   | `nodes/node.rb:179`              | Abstract methods raise bare `NotImplementedError` with no context  | [#114][gh_114]                    |
 | [x]  | 19 | **Medium**   | `provider_collection.rb:109`     | Dead `\|\| raise` and broken `default=` on empty collections       | [#107][gh_107]                    |
 | [x]  | 20 | **Medium**   | `compressible.rb:10`             | Yoda condition `1 == children_tree.size`                           | [#102][gh_102]                    |
 | [x]  | 21 | **Medium**   | `serializers/zip.rb:33`          | Indirect `File.basename` extraction path obscures intent           | [#104][gh_104]                    |
@@ -737,4 +737,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_107]: https://github.com/gonzedge/rambling-trie/pull/107
 [gh_108]: https://github.com/gonzedge/rambling-trie/pull/108
 [gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
+[gh_114]: https://github.com/gonzedge/rambling-trie/pull/114
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -17,7 +17,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 34 | **High**     | `sig/lib/rambling/trie/readers/plain_text.rbs:5` | `PlainText#each_word` RBS yields `String?` but Ruby code always yields `String` | [#111][gh_111] |
 | [x]  | 35 | **High**     | `sig/lib/rambling/trie/nodes/compressed.rbs:7` | `Compressed#add` RBS signature is stricter than parent `Node#add` (contravariant-unsafe) | [#111][gh_111] |
 | [x]  | 16 | **Medium**   | `trie.rb:77`                             | `@properties` lazy init is not thread-safe (carried from prior review)       | [#113][gh_113] |
-| [ ]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) |                |
+| [x]  | 18 | **Medium**   | `nodes/node.rb:173,177,181,185`          | Abstract methods raise bare `NotImplementedError` with no context (carried from prior review) | [#114][gh_114] |
 | [x]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable | [#111][gh_111] |
 | [x]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` | [#111][gh_111] |
 | [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
@@ -660,4 +660,5 @@ docstring:
 [gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [gh_111]: https://github.com/gonzedge/rambling-trie/pull/111
 [gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
+[gh_114]: https://github.com/gonzedge/rambling-trie/pull/114
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -2,7 +2,7 @@
 
 path = File.join 'rambling', 'trie'
 %w(
-  comparable compressible compressor configuration container enumerable inspectable invalid_operation
+  comparable compressible compressor configuration container enumerable inspectable invalid_operation not_implemented
   readers serializers stringifyable nodes version
 ).each { |file| require File.join(path, file) }
 

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -169,20 +169,26 @@ module Rambling
 
         attr_accessor :terminal
 
-        # abstract methods
-
+        # @abstract Subclass and override {#children_match_prefix} to match a prefix against child nodes.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def children_match_prefix _chars
           not_implemented
         end
 
+        # @abstract Subclass and override {#partial_word_chars?} to check for a partial-word path.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def partial_word_chars? _chars
           not_implemented
         end
 
+        # @abstract Subclass and override {#word_chars?} to check for a full-word path.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def word_chars? _chars
           not_implemented
         end
 
+        # @abstract Subclass and override {#closest_node} to return the deepest matching node.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def closest_node _chars
           not_implemented
         end

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -7,6 +7,7 @@ module Rambling
       # :reek:MissingSafeMethod { exclude: [ terminal! ] }
       # :reek:RepeatedConditional { max_ifs: 3 }
       class Node
+        include NotImplemented
         include Rambling::Trie::Compressible
         include Rambling::Trie::Enumerable
         include Rambling::Trie::Comparable
@@ -171,19 +172,19 @@ module Rambling
         # abstract methods
 
         def children_match_prefix _chars
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
 
         def partial_word_chars? _chars
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
 
         def word_chars? _chars
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
 
         def closest_node _chars
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
       end
     end

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -170,20 +170,20 @@ module Rambling
 
         # abstract methods
 
-        def children_match_prefix chars
-          raise NotImplementedError
+        def children_match_prefix _chars
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
 
-        def partial_word_chars? chars
-          raise NotImplementedError
+        def partial_word_chars? _chars
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
 
-        def word_chars? chars
-          raise NotImplementedError
+        def word_chars? _chars
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
 
-        def closest_node chars
-          raise NotImplementedError
+        def closest_node _chars
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
       end
     end

--- a/lib/rambling/trie/not_implemented.rb
+++ b/lib/rambling/trie/not_implemented.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Rambling
+  # :reek:IrresponsibleModule (unclear why this is necessary here but not in other submodules)
   module Trie
     # Provides a private helper for marking abstract methods.
     # @api private

--- a/lib/rambling/trie/not_implemented.rb
+++ b/lib/rambling/trie/not_implemented.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Rambling
+  module Trie
+    # Provides a private helper for marking abstract methods.
+    # @api private
+    module NotImplemented
+      private
+
+      # Raises {NotImplementedError} with the concrete class and calling method name.
+      # @raise [NotImplementedError] always, with message
+      #   <code>"ClassName#method_name is not implemented"</code>
+      # @return [void]
+      def not_implemented
+        raise NotImplementedError,
+          "#{self.class}##{caller_locations(1, 1)&.first&.label} is not implemented"
+      end
+    end
+
+    private_constant :NotImplemented
+  end
+end

--- a/lib/rambling/trie/readers/reader.rb
+++ b/lib/rambling/trie/readers/reader.rb
@@ -10,8 +10,8 @@ module Rambling
         # @param [String] filepath the full path of the file to load the words from.
         # @yield [String] Each line read from the file.
         # @return [self]
-        def each_word filepath
-          raise NotImplementedError
+        def each_word _filepath
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
       end
     end

--- a/lib/rambling/trie/readers/reader.rb
+++ b/lib/rambling/trie/readers/reader.rb
@@ -5,13 +5,15 @@ module Rambling
     module Readers
       # Base class for all readers.
       class Reader
+        include NotImplemented
+
         # Yields each word read from given file.
         # @abstract Subclass and override {#each_word} to fit to a particular file format.
         # @param [String] filepath the full path of the file to load the words from.
         # @yield [String] Each line read from the file.
         # @return [self]
         def each_word _filepath
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
       end
     end

--- a/lib/rambling/trie/readers/reader.rb
+++ b/lib/rambling/trie/readers/reader.rb
@@ -12,6 +12,7 @@ module Rambling
         # @param [String] filepath the full path of the file to load the words from.
         # @yield [String] Each line read from the file.
         # @return [self]
+        # @raise [NotImplementedError] when not overridden by a subclass
         def each_word _filepath
           not_implemented
         end

--- a/lib/rambling/trie/serializers/serializer.rb
+++ b/lib/rambling/trie/serializers/serializer.rb
@@ -5,12 +5,14 @@ module Rambling
     module Serializers
       # Base class for all serializers.
       class Serializer
+        include NotImplemented
+
         # Loads contents from a specified filepath.
         # @abstract Subclass and override {#load} to parse the desired format.
         # @param [String] filepath the filepath to load contents from.
         # @return [TContents] parsed contents from given file.
         def load _filepath
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
 
         # Dumps contents into a specified filepath.
@@ -19,7 +21,7 @@ module Rambling
         # @param [String] filepath the filepath to dump the contents to.
         # @return [Numeric] number of bytes written to disk.
         def dump _contents, _filepath
-          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
+          not_implemented
         end
       end
     end

--- a/lib/rambling/trie/serializers/serializer.rb
+++ b/lib/rambling/trie/serializers/serializer.rb
@@ -11,6 +11,7 @@ module Rambling
         # @abstract Subclass and override {#load} to parse the desired format.
         # @param [String] filepath the filepath to load contents from.
         # @return [TContents] parsed contents from given file.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def load _filepath
           not_implemented
         end
@@ -20,6 +21,7 @@ module Rambling
         # @param [TContents] contents the contents to dump into given file.
         # @param [String] filepath the filepath to dump the contents to.
         # @return [Numeric] number of bytes written to disk.
+        # @raise [NotImplementedError] when not overridden by a subclass
         def dump _contents, _filepath
           not_implemented
         end

--- a/lib/rambling/trie/serializers/serializer.rb
+++ b/lib/rambling/trie/serializers/serializer.rb
@@ -9,8 +9,8 @@ module Rambling
         # @abstract Subclass and override {#load} to parse the desired format.
         # @param [String] filepath the filepath to load contents from.
         # @return [TContents] parsed contents from given file.
-        def load filepath
-          raise NotImplementedError
+        def load _filepath
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
 
         # Dumps contents into a specified filepath.
@@ -18,8 +18,8 @@ module Rambling
         # @param [TContents] contents the contents to dump into given file.
         # @param [String] filepath the filepath to dump the contents to.
         # @return [Numeric] number of bytes written to disk.
-        def dump contents, filepath
-          raise NotImplementedError
+        def dump _contents, _filepath
+          raise NotImplementedError, "#{self.class}##{__method__} is not implemented"
         end
       end
     end

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -2,6 +2,7 @@ module Rambling
   module Trie
     module Nodes
       class Node[TValue < BasicObject & _Inspect & _Nilable]
+        include NotImplemented
         include Compressible[TValue]
         include Enumerable[TValue]
         include Comparable[TValue]

--- a/sig/lib/rambling/trie/not_implemented.rbs
+++ b/sig/lib/rambling/trie/not_implemented.rbs
@@ -1,0 +1,10 @@
+module Rambling
+  module Trie
+    # @api private
+    module NotImplemented : ::Object
+      private
+
+      def not_implemented: () -> bot
+    end
+  end
+end

--- a/sig/lib/rambling/trie/readers/reader.rbs
+++ b/sig/lib/rambling/trie/readers/reader.rbs
@@ -2,6 +2,8 @@ module Rambling
   module Trie
     module Readers
       class Reader
+        include NotImplemented
+
         def each_word: (String) { (String) -> void } -> (Enumerator[String, void] | Reader)
       end
     end

--- a/sig/lib/rambling/trie/serializers/serializer.rbs
+++ b/sig/lib/rambling/trie/serializers/serializer.rbs
@@ -2,6 +2,8 @@ module Rambling
   module Trie
     module Serializers
       class Serializer[TContents]
+        include NotImplemented
+
         def load: (String) -> TContents
         def dump: (TContents, String) -> Numeric
       end

--- a/spec/lib/rambling/trie/nodes/node_spec.rb
+++ b/spec/lib/rambling/trie/nodes/node_spec.rb
@@ -10,7 +10,8 @@ describe Rambling::Trie::Nodes::Node do
   %i(children_match_prefix partial_word_chars? word_chars? closest_node).each do |abstract_method|
     it "does not implement #{abstract_method} (abstract private method)" do
       expect { node.send abstract_method, %w(o n e) }
-        .to raise_error NotImplementedError, /#{Regexp.escape "#{described_class}##{abstract_method}"} is not implemented/
+        .to raise_error NotImplementedError,
+          %r{#{Regexp.escape "#{described_class}##{abstract_method}"} is not implemented}
     end
   end
 end

--- a/spec/lib/rambling/trie/nodes/node_spec.rb
+++ b/spec/lib/rambling/trie/nodes/node_spec.rb
@@ -10,7 +10,7 @@ describe Rambling::Trie::Nodes::Node do
   %i(children_match_prefix partial_word_chars? word_chars? closest_node).each do |abstract_method|
     it "does not implement #{abstract_method} (abstract private method)" do
       expect { node.send abstract_method, %w(o n e) }
-        .to raise_error NotImplementedError, /#{described_class}##{abstract_method} is not implemented/
+        .to raise_error NotImplementedError, /#{Regexp.escape "#{described_class}##{abstract_method}"} is not implemented/
     end
   end
 end

--- a/spec/lib/rambling/trie/nodes/node_spec.rb
+++ b/spec/lib/rambling/trie/nodes/node_spec.rb
@@ -10,7 +10,7 @@ describe Rambling::Trie::Nodes::Node do
   %i(children_match_prefix partial_word_chars? word_chars? closest_node).each do |abstract_method|
     it "does not implement #{abstract_method} (abstract private method)" do
       expect { node.send abstract_method, %w(o n e) }
-        .to raise_error NotImplementedError
+        .to raise_error NotImplementedError, /#{described_class}##{abstract_method} is not implemented/
     end
   end
 end

--- a/spec/lib/rambling/trie/readers/reader_spec.rb
+++ b/spec/lib/rambling/trie/readers/reader_spec.rb
@@ -8,7 +8,7 @@ describe Rambling::Trie::Readers::Reader do
   describe '#each_word' do
     it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { reader.each_word('any-file.zip') }
-        .to raise_error NotImplementedError, /#{described_class}#each_word is not implemented/
+        .to raise_error NotImplementedError, %r{#{described_class}#each_word is not implemented}
     end
   end
 end

--- a/spec/lib/rambling/trie/readers/reader_spec.rb
+++ b/spec/lib/rambling/trie/readers/reader_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe Rambling::Trie::Readers::Reader do
   subject(:reader) { described_class.new }
 
-  describe '#load' do
-    it 'is an abstract method that raises NotImplementedError' do
+  describe '#each_word' do
+    it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { reader.each_word('any-file.zip') }
-        .to raise_exception NotImplementedError
+        .to raise_error NotImplementedError, /#{described_class}#each_word is not implemented/
     end
   end
 end

--- a/spec/lib/rambling/trie/serializers/serializer_spec.rb
+++ b/spec/lib/rambling/trie/serializers/serializer_spec.rb
@@ -6,16 +6,16 @@ describe Rambling::Trie::Serializers::Serializer do
   subject(:serializer) { described_class.new }
 
   describe '#load' do
-    it 'is an abstract method that raises NotImplementedError' do
+    it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { serializer.load('any-file.zip') }
-        .to raise_exception NotImplementedError
+        .to raise_error NotImplementedError, /#{described_class}#load is not implemented/
     end
   end
 
   describe '#dump' do
-    it 'is an abstract method that raises NotImplementedError' do
+    it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { serializer.dump('any contents', 'any-file.zip') }
-        .to raise_exception NotImplementedError
+        .to raise_error NotImplementedError, /#{described_class}#dump is not implemented/
     end
   end
 end

--- a/spec/lib/rambling/trie/serializers/serializer_spec.rb
+++ b/spec/lib/rambling/trie/serializers/serializer_spec.rb
@@ -8,14 +8,14 @@ describe Rambling::Trie::Serializers::Serializer do
   describe '#load' do
     it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { serializer.load('any-file.zip') }
-        .to raise_error NotImplementedError, /#{described_class}#load is not implemented/
+        .to raise_error NotImplementedError, %r{#{described_class}#load is not implemented}
     end
   end
 
   describe '#dump' do
     it 'is an abstract method that raises NotImplementedError with class and method name' do
       expect { serializer.dump('any contents', 'any-file.zip') }
-        .to raise_error NotImplementedError, /#{described_class}#dump is not implemented/
+        .to raise_error NotImplementedError, %r{#{described_class}#dump is not implemented}
     end
   end
 end


### PR DESCRIPTION
_Deals with issue no. 18 in [doc/20260418-claude-code-review.md](doc/20260418-claude-code-review.md) and [doc/20260411-claude-code-review.md](doc/20260411-claude-code-review.md)._

Currently, abstract method stubs in `Node`, `Reader`, and `Serializer` raise bare `NotImplementedError`s with no additional context, which obscures a bit which subclass' method is not implemented yet.

This PR:

- Introduces `Rambling::Trie::NotImplemented`, a private mixin that provides a single `not_implemented` helper used by all abstract method stubs
  - `not_implemented` raises `NotImplementedError` with the concrete class name and calling method name via `caller_locations`
  - now results in this message: `NotImplementedError: Rambling::Trie::Nodes::Raw#word_chars? is not implemented`
- Replaces all bare `raise NotImplementedError` in `Node`, `Reader`, and `Serializer` with `not_implemented`
- Adds `@raise [NotImplementedError]` to all abstract method docstrings
- Adds corresponding type signature with `-> bot` and `module NotImplemented : ::Object` tricks to make the definition more flexible