### PR TITLE
Add `CLAUDE.md` and mark issue no 39 as won't fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1408,6 +1408,7 @@ Most of these help with the gem's overall performance.
 [github_pull_111]: https://github.com/gonzedge/rambling-trie/pull/111
 [github_pull_112]: https://github.com/gonzedge/rambling-trie/pull/112
 [github_pull_113]: https://github.com/gonzedge/rambling-trie/pull/113
+[github_pull_114]: https://github.com/gonzedge/rambling-trie/pull/114
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md — rambling-trie
+
+## Project overview
+
+`rambling-trie` is a Ruby gem implementing a compressed trie data structure. The main entry point
+is `Rambling::Trie` (`lib/rambling/trie.rb`). Node types live under `lib/rambling/trie/nodes/`.
+
+## Commands
+
+```sh
+bundle exec rake spec        # run tests
+bundle exec rake reek        # run reek smell detector
+bundle exec rake rubocop     # run RuboCop linter
+bundle exec rake steep       # run Steep type checker
+bundle exec rake             # runs all of the above (spec + reek + rubocop + steep)
+```
+
+## Workflow
+
+Each issue gets its own branch and PR. Use spec-first TDD:
+
+1. Write failing spec(s), commit with `git add <files>`
+2. Confirm failure with `bundle exec rspec <spec_file>`
+3. Implement the fix, commit
+4. Run the full suite: `bundle exec rake spec`
+5. Run Rubocop: `bundle exec rake rubocop`
+6. Run Steep: `bundle exec rake steep`
+7. Run Reek: `bundle exec rake reek`
+8. Prompt the user for PR number
+9. Update CHANGELOG and both code review docs, commit
+
+_**NOTE:** Never attempt to create a PR_.
+
+## Git conventions
+
+- Branch names: `gonzedge/<short-description>`
+- Commit body (for issue-linked commits):
+  `_Deals with issue no. N in [doc/20260418-claude-code-review.md](doc/20260418-claude-code-review.md)._`
+- Doc files are gitignored; stage them with `git add -f doc/...` but prompt the user before staging a new one
+
+_**NOTE:** Never attempt to do a `git push`_.
+
+## PR descriptions (raw markdown, no formatting by Claude)
+
+- Title: sentence case, no trailing period
+- Problem context in **present tense** (not past)
+- Use "deals with" (not "addresses") and no `#` before issue number
+- Include "This PR:" section describing what the PR does
+- No line-length restrictions
+- No em-dashes (–)
+
+## CHANGELOG format
+
+File: `CHANGELOG.md`
+
+```
+## <version> (in development)
+
+### Enhancements
+
+#### Major
+- ...
+
+#### Minor
+- ...
+```
+
+- No "Bug Fixes" section — all entries go under Enhancements (Major or Minor)
+- New entries always appended at the **bottom** of their section
+- Entry format: `- <PR title> ([#N][github_pull_N]) by [@gonzedge][github_user_gonzedge]`
+- Add matching link definition: `[github_pull_N]: https://github.com/gonzedge/rambling-trie/pull/N` after all other PR
+  links
+
+## Code review docs
+
+Two files track ongoing review work:
+- `doc/20260418-claude-code-review.md` (primary, newer)
+- `doc/20260411-claude-code-review.md` (earlier review; update when issues appear in both)
+
+When an issue is fixed: mark `[x]` in the summary table and add `[#N][gh_N]` in the PR column.
+When an issue is skipped: mark `[-]`, link to a `[feedback][fb_N]` section explaining why.
+Link definition format: `[gh_N]: https://github.com/gonzedge/rambling-trie/pull/N`
+Add both `gh_N` and `fb_N` link definitions at the bottom of the corresponding section within the links list.
+
+_**NOTE:** Never use em-dashes (—)._
+
+## Type signatures (RBS + Steep)
+
+Every new module or class needs a corresponding `.rbs` file under `sig/lib/`.
+After adding Ruby code, run `bundle exec steep check` and fix all errors before committing.
+
+Key patterns:
+- `module Foo : ::Object` — self-type constraint so `self.class`, `raise`, etc. resolve
+- `-> bot` — return type for methods that always raise (subtype of everything)
+- `private_constant` constants still need RBS declarations (with `# private` comment if needed)
+
+## Reek suppressions
+
+Inline suppressions go on the line **above** the class/module/method:
+
+```ruby
+# :reek:IrresponsibleModule
+module Trie
+```
+
+For method-specific exclusions, prefer `.reek.yml` entries over inline comments.
+
+## RBS + includes
+
+When a module is included via unqualified name (e.g., `include NotImplemented`) because it is a
+`private_constant`, add `include NotImplemented` to the including class's `.rbs` file as well.

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -21,7 +21,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 36 | **Medium**   | `sig/lib/rambling/trie/comparable.rbs:10,12`, `inspectable.rbs:23,25`, `stringifyable.rbs:12` | Abstract `letter`/`value` typed as non-nullable but concrete `Node` is nullable | [#111][gh_111] |
 | [x]  | 37 | **Medium**   | `sig/lib/rambling/trie/container.rbs:23,27,29` | `partial_word?`/`word?`/`scan` RBS require `String` argument but Ruby defaults to `''` | [#111][gh_111] |
 | [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
-| [ ]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              |                |
+| [-]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              | [feedback][fb_39] |
 | [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |
 | [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
 | [ ]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     |                |
@@ -176,6 +176,14 @@ direct users.
 > tried and caused a ~38% regression in compression time and ~244% regression in compressed trie serialization time.
 > The `Compressor` is the only caller of `Compressed#initialize` with a non-empty tree, and it always builds fresh
 > trees, so the footgun is theoretical rather than practical.
+
+#### Feedback for issue 39
+
+> Won't fix. The `|| raise` is not truly dead; it serves as a Steep type-narrowing idiom. Steep cannot narrow
+> `TProvider | nil` to `TProvider` after a `.nil?` guard when `TProvider` is bounded by `_Nilable`, because the
+> bound itself allows `.nil?` to return `true` for `TProvider` instances. The `|| raise` makes the right-hand side
+> of `include?` typed as `TProvider` (since `raise` has type `bot`). The alternative (`# steep:ignore`) was
+> considered and rejected in favour of keeping the intent in code.
 
 Benchmark diff (base: commit `172e418`, fix: commit `da8e3c5`):
 
@@ -650,12 +658,13 @@ docstring:
 
 [fb_6]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-6
 [fb_10]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-10
-[fb_13]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-13
 [fb_11]: /gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md#feedback-for-issue-11
+[fb_13]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-13
 [fb_15]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-15
 [fb_23]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-23
 [fb_24]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-24
 [fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
+[fb_39]: /gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md#feedback-for-issue-39
 [gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [gh_111]: https://github.com/gonzedge/rambling-trie/pull/111


### PR DESCRIPTION
_Rejects issue no. 36 in [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

Marking ad won't fix, because `|| raise`nserves as a Steep type-narrowing idiom; `TProvider | nil` cannot be narrowed down to `TProvider` even after a `.nil?`. The alternative (`# steep:ignore`) was considered and rejected in favor of keeping the intent in code.

---

Also, add `CLAUDE.md` definition, finally.