### PR TITLE
Mark issue 42 won't fix; revert incidental `|| raise` messages

### DIFF
--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -25,7 +25,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |
 | [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
 | [x]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     | [#115][gh_116] |
-| [ ]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message |                |
+| [-]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message | [feedback][fb_42] |
 | [ ]  | 43 | **Low**      | `lib/rambling/trie/nodes/node.rb:38-46`  | Default `children_tree = {}` arg creates fresh hash per call but signals shared-hash ownership with caller |                |
 
 ---
@@ -184,6 +184,15 @@ direct users.
 > bound itself allows `.nil?` to return `true` for `TProvider` instances. The `|| raise` makes the right-hand side
 > of `include?` typed as `TProvider` (since `raise` has type `bot`). The alternative (`# steep:ignore`) was
 > considered and rejected in favour of keeping the intent in code.
+
+#### Feedback for issue 42
+
+> Won't fix. Every bare `|| raise` in this codebase exists solely as a Steep type-narrowing idiom; `raise` has
+> type `bot` (never returns), which narrows the left-hand side from a nullable type to its non-nil form. These
+> raises are not defensive runtime assertions; they exist to satisfy the type checker. Adding messages would
+> suggest they are expected to fire, which they are not. Three incidental occurrences that had acquired messages
+> (`compressed.rb:39,45` from #109 and `container.rb:216` from #111) were reverted to bare `|| raise` for
+> consistency.
 
 Benchmark diff (base: commit `172e418`, fix: commit `da8e3c5`):
 
@@ -665,6 +674,7 @@ docstring:
 [fb_24]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-24
 [fb_25]: /gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md#feedback-for-issue-25
 [fb_39]: /gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md#feedback-for-issue-39
+[fb_42]: /gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md#feedback-for-issue-42
 [gh_109]: https://github.com/gonzedge/rambling-trie/pull/109
 [gh_110]: https://github.com/gonzedge/rambling-trie/pull/110
 [gh_111]: https://github.com/gonzedge/rambling-trie/pull/111

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -213,7 +213,7 @@ module Rambling
 
         chars = phrase.chars
         chars.each_index do |starting_index|
-          new_phrase = chars[starting_index..] || raise('slice returned nil in words_within_root')
+          new_phrase = chars[starting_index..] || raise
           root.match_prefix(new_phrase) { |word| yield word }
         end
 

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -36,13 +36,13 @@ module Rambling
         private
 
         def partial_word_chars? chars
-          child = children_tree[(chars.first || raise('empty chars in partial_word_chars?')).to_sym]
+          child = children_tree[(chars.first || raise).to_sym]
           return false unless child
 
           child_letter = child.letter.to_s
 
           if chars.size >= child_letter.size
-            letter = (chars.shift(child_letter.size) || raise('shift returned nil in partial_word_chars?')).join
+            letter = (chars.shift(child_letter.size) || raise).join
             return false unless child_letter == letter
 
             child.partial_word? chars


### PR DESCRIPTION
_Rejects issue no. 42 in [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

All bare `|| raise` patterns are Steep type-narrowing idioms, not runtime assertions. Three occurrences that had acquired messages incidentally (`compressed.rb:39,45` from #109, `container.rb:216` from #111) are reverted to bare `|| raise` for consistency.