### PR TITLE
Document `children_tree` ownership contract in `Node#initialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,9 @@
   - Adds `@raise [NotImplementedError]` to all abstract method docstrings
   - Adds corresponding type signature with `-> bot` and `module NotImplemented : ::Object` tricks to make the definition
     more flexible
-- Rename duplicate `_` params in `Compressed#add` to `_word` and `_value` ([#115][github_pull_116])
+- Rename duplicate `_` params in `Compressed#add` to `_word` and `_value` ([#116][github_pull_116])
+  by [@gonzedge][github_user_gonzedge]
+- Document `children_tree` ownership contract in `Node#initialize` ([#118][github_pull_118])
   by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
@@ -1411,7 +1413,10 @@ Most of these help with the gem's overall performance.
 [github_pull_112]: https://github.com/gonzedge/rambling-trie/pull/112
 [github_pull_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [github_pull_114]: https://github.com/gonzedge/rambling-trie/pull/114
-[github_pull_116]: https://github.com/gonzedge/rambling-trie/pull/115
+[github_pull_115]: https://github.com/gonzedge/rambling-trie/pull/115
+[github_pull_116]: https://github.com/gonzedge/rambling-trie/pull/116
+[github_pull_117]: https://github.com/gonzedge/rambling-trie/pull/117
+[github_pull_118]: https://github.com/gonzedge/rambling-trie/pull/118
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -24,9 +24,9 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [-]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              | [feedback][fb_39] |
 | [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |
 | [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
-| [x]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     | [#115][gh_116] |
+| [x]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     | [#116][gh_116] |
 | [-]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message | [feedback][fb_42] |
-| [ ]  | 43 | **Low**      | `lib/rambling/trie/nodes/node.rb:38-46`  | Default `children_tree = {}` arg creates fresh hash per call but signals shared-hash ownership with caller |                |
+| [x]  | 43 | **Low**      | `lib/rambling/trie/nodes/node.rb:38-46`  | Default `children_tree = {}` arg creates fresh hash per call but signals shared-hash ownership with caller | [#118][gh_118] |
 
 ---
 
@@ -681,4 +681,6 @@ docstring:
 [gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [gh_114]: https://github.com/gonzedge/rambling-trie/pull/114
 [gh_116]: https://github.com/gonzedge/rambling-trie/pull/116
+[gh_117]: https://github.com/gonzedge/rambling-trie/pull/117
+[gh_118]: https://github.com/gonzedge/rambling-trie/pull/118
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -39,11 +39,13 @@ module Rambling
         # Creates a new node.
         # @param [Symbol, nil] letter the Node's letter value.
         # @param [Node, nil] parent the parent of the current node.
-        # @param [Hash<Symbol, Node>] children_tree the children tree of the current node.
-        def initialize letter = nil, parent = nil, children_tree = {}
+        # @param [Hash<Symbol, Node>, nil] children_tree the children tree of the current node,
+        #   or +nil+ to start with an empty tree. When a hash is provided, ownership transfers
+        #   to the node; callers must not retain references to or mutate the hash after passing it.
+        def initialize letter = nil, parent = nil, children_tree = nil
           @letter = letter
           @parent = parent
-          @children_tree = children_tree
+          @children_tree = children_tree || {}
         end
 
         # Child nodes.

--- a/sig/lib/rambling/trie/nodes/node.rbs
+++ b/sig/lib/rambling/trie/nodes/node.rbs
@@ -14,7 +14,7 @@ module Rambling
         attr_accessor parent: Node[TValue]?
         attr_accessor value: TValue?
 
-        def initialize: (?Symbol?, ?Node[TValue]?, ?Hash[Symbol, Node[TValue]]) -> void
+        def initialize: (?Symbol?, ?Node[TValue]?, ?Hash[Symbol, Node[TValue]]?) -> void
 
         def add: (Array[Symbol], ?TValue?) -> Node[TValue]
 


### PR DESCRIPTION
_Deals with issue no. 43 in [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

This PR:

- Defaults `children_tree` to `nil` and initialize to `{}` inline
- Adds ownership/mutation warning to the docstring for when a hash is passed