### PR TITLE
Fix YARD documentation inaccuracies across multiple files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
   by [@gonzedge][github_user_gonzedge]
 - Document `children_tree` ownership contract in `Node#initialize` ([#118][github_pull_118])
   by [@gonzedge][github_user_gonzedge]
+- Fix YARD documentation inaccuracies across multiple files ([#119][github_pull_119])
+  by [@gonzedge][github_user_gonzedge]
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1417,6 +1419,7 @@ Most of these help with the gem's overall performance.
 [github_pull_116]: https://github.com/gonzedge/rambling-trie/pull/116
 [github_pull_117]: https://github.com/gonzedge/rambling-trie/pull/117
 [github_pull_118]: https://github.com/gonzedge/rambling-trie/pull/118
+[github_pull_119]: https://github.com/gonzedge/rambling-trie/pull/119
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/lib/rambling/trie.rb
+++ b/lib/rambling/trie.rb
@@ -20,13 +20,13 @@ module Rambling
       # @return [Container] the trie just created.
       # @yield [Container] the trie just created.
       # @see Rambling::Trie::Readers Readers.
-      def create filepath = nil, input_reader = nil
+      def create filepath = nil, reader = nil
         root = root_builder.call
 
         Rambling::Trie::Container.new root, compressor do |container|
           if filepath
-            reader = input_reader || readers.resolve(filepath) || raise(ArgumentError, "no reader for #{filepath}")
-            reader.each_word(filepath) { |word| container << word }
+            input_reader = reader || readers.resolve(filepath) || raise(ArgumentError, "no reader for #{filepath}")
+            input_reader.each_word(filepath) { |word| container << word }
           end
 
           yield container if block_given? # steep:ignore

--- a/lib/rambling/trie/comparable.rb
+++ b/lib/rambling/trie/comparable.rb
@@ -6,8 +6,9 @@ module Rambling
     module Comparable
       # Compares two nodes.
       # @param [Nodes::Node] other the node to compare against.
-      # @return [Boolean] `true` if the nodes' {Nodes::Node#letter #letter} and
-      #   {Nodes::Node#children_tree #children_tree} are equal, `false` otherwise.
+      # @return [Boolean] `true` if the nodes' {Nodes::Node#letter #letter},
+      #   {Nodes::Node#terminal? #terminal?}, {Nodes::Node#value #value}, and
+      #   {Nodes::Node#children_tree #children_tree} are all equal, `false` otherwise.
       def == other
         letter == other.letter &&
           terminal? == other.terminal? &&

--- a/lib/rambling/trie/configuration/provider_collection.rb
+++ b/lib/rambling/trie/configuration/provider_collection.rb
@@ -17,7 +17,6 @@ module Rambling
         #   providers.
         #   @param [TProvider] provider the provider to use as default.
         #   @raise [ArgumentError] when the given provider is not in the provider collection.
-        #   @note If no providers have been configured, `nil` will be assigned.
         # @return [TProvider, nil] the default provider to use when a provider cannot be resolved in
         #   {ProviderCollection#resolve #resolve}.
         attr_reader :default
@@ -25,7 +24,8 @@ module Rambling
         # Creates a new provider collection.
         # @param [Symbol] name the name for this provider collection.
         # @param [Hash<Symbol, TProvider>] providers the configured providers.
-        # @param [TProvider, nil] default the configured default provider.
+        # @param [TProvider, nil] default the configured default provider. When +nil+ (or no providers
+        #   are given), falls back to the first configured provider, or +nil+ if none exist.
         def initialize name, providers = {}, default = nil
           @name = name
           @configured_providers = providers
@@ -74,9 +74,9 @@ module Rambling
           self.default = configured_default
         end
 
-        # Get provider corresponding to a given format.
-        # @return [Array<Symbol>] the provider corresponding to that format.
-        # @see https://ruby-doc.org/3.3.0/Hash.html#method-i-5B-5D
+        # List the formats of configured providers.
+        # @return [Array<Symbol>] the formats of all configured providers.
+        # @see https://ruby-doc.org/3.3.0/Hash.html#method-i-keys
         #   Hash#keys
         def formats
           providers.keys
@@ -84,7 +84,7 @@ module Rambling
 
         # Get provider corresponding to a given format.
         # @param [Symbol] format the format to search for in the collection.
-        # @return [TProvider] the provider corresponding to that format.
+        # @return [TProvider, nil] the provider corresponding to that format, or +nil+ if not found.
         # @see https://ruby-doc.org/3.3.0/Hash.html#method-i-5B-5D Hash#[]
         def [] format
           providers[format]

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -22,7 +22,8 @@ module Rambling
       end
 
       # Adds a word to the trie.
-      # @param [String] word the word to add the branch from.
+      # @param [String] word the word to add to the trie.
+      # @param [Object, nil] value the value to associate with the word.
       # @return [Nodes::Node] the just added branch's root node.
       # @raise [InvalidOperation] if the trie is already compressed.
       # @see Nodes::Raw#add
@@ -32,9 +33,11 @@ module Rambling
       end
 
       # Adds all provided words to the trie.
-      # @param [Array<String>] words the words to add the branch from.
+      # @param [Array<String>] words the words to add to the trie.
+      # @param [Array<Object>, nil] values the values to associate with each word, in the same order.
       # @return [Array<Nodes::Node>] the collection of nodes added.
       # @raise [InvalidOperation] if the trie is already compressed.
+      # @raise [ArgumentError] if words and values are given but differ in size.
       # @see Nodes::Raw#add
       # @see Nodes::Compressed#add
       def concat words, values = nil
@@ -80,7 +83,7 @@ module Rambling
       end
 
       # Adds all provided words to the trie.
-      # @param [Array<String>] words the words to add the branch from.
+      # @param [String] words the words to add to the trie.
       # @return [Array<Nodes::Node>] the collection of nodes added.
       # @raise [InvalidOperation] if the trie is already compressed.
       # @see #concat
@@ -110,7 +113,6 @@ module Rambling
       # Returns all words within a string that match a word contained in the trie.
       # @param [String] phrase the string to look for matching words in.
       # @return [Array<String>] all the words in the given string that match a word in the trie.
-      # @yield [String] each word found in phrase.
       def words_within phrase
         words_within_root(phrase).to_a
       end

--- a/lib/rambling/trie/nodes/compressed.rb
+++ b/lib/rambling/trie/nodes/compressed.rb
@@ -21,8 +21,7 @@ module Rambling
         # trying to add a word to the current compressed trie node
         # @param [Array<Symbol>] _word the word chars to add to the trie.
         # @param [Object, nil] _value the value to associate with the word.
-        # @raise [InvalidOperation] if the trie is already compressed.
-        # @return [void]
+        # @raise [InvalidOperation] always.
         def add _word, _value = nil
           raise Rambling::Trie::InvalidOperation, 'Cannot add word to compressed trie'
         end

--- a/lib/rambling/trie/nodes/node.rb
+++ b/lib/rambling/trie/nodes/node.rb
@@ -134,7 +134,7 @@ module Rambling
         end
 
         # Set the {Node Node} that corresponds to a given letter.
-        # @param [Symbol] letter the letter to insert or update in the node's
+        # @param [Symbol] letter the letter to insert or update in the node's children tree.
         # @param [Node] node the {Node Node} to assign to that letter.
         # @return [Node] the node corresponding to the inserted or updated letter.
         # @see https://ruby-doc.org/3.3.0/Hash.html#method-i-5B-5D Hash#[]

--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -9,7 +9,7 @@ module Rambling
         # Adds a word to the current raw (uncompressed) trie node.
         # @param [Array<Symbol>] reversed_chars the char array to add to the trie, in reverse order.
         # @return [Node] the added/modified node based on the word added.
-        # @note This method clears the contents of the chars variable.
+        # @note This method consumes the array by popping each element during recursion, leaving it empty on return.
         def add reversed_chars, value = nil
           if reversed_chars.empty?
             unless root?

--- a/lib/rambling/trie/serializers/zip.rb
+++ b/lib/rambling/trie/serializers/zip.rb
@@ -18,7 +18,7 @@ module Rambling
         # Unzip contents from specified filepath and load in contents from
         # unzipped files.
         # @param [String] filepath the filepath to load contents from.
-        # @return [TContents] all contents of the unzipped loaded file.
+        # @return [Nodes::Node] all contents of the unzipped loaded file.
         # @see https://github.com/rubyzip/rubyzip#reading-a-zip-file Zip
         #   reading a file
         def load filepath
@@ -43,7 +43,7 @@ module Rambling
         # Dumps contents and zips into a specified filepath.
         # @param [String] contents the contents to dump.
         # @param [String] filepath the filepath to dump the contents to.
-        # @return [TContents] number of bytes written to disk.
+        # @return [Integer] number of bytes written to disk.
         # @see https://github.com/rubyzip/rubyzip#basic-zip-archive-creation
         #   Zip archive creation
         def dump contents, filepath

--- a/lib/rambling/trie/stringifyable.rb
+++ b/lib/rambling/trie/stringifyable.rb
@@ -6,7 +6,7 @@ module Rambling
     module Stringifyable
       # String representation of the current node, if it is a terminal node.
       # @return [String] the string representation of the current node.
-      # @raise [InvalidOperation] if node is not terminal or is root.
+      # @raise [InvalidOperation] if the node has a letter and is not terminal.
       def as_word
         raise Rambling::Trie::InvalidOperation, 'Cannot represent branch as a word' if letter && !terminal?
 


### PR DESCRIPTION
- Remove erroneous `@yield` from `Container#words_within` (method does not yield)
- Fix `Container#push` `@param` type from `[Array<String>]` to `[String]` (splat param)
- Add missing `@param` for `value`/`values` in `Container#add` and `#concat`; improve descriptions
- Complete truncated `Node#[]=` param description ("in the node's children tree")
- Remove misleading `@return [void]` from `Compressed#add` (always raises)
- Fix `ProviderCollection#formats` prose and `@return` (copy-pasted from `[]`)
- Fix `ProviderCollection#[]` `@return` to reflect nil possibility
- Move misplaced `@note` from `ProviderCollection#default=` to `#initialize` `@param`
- Fix `Serializers::Zip#dump` `@return` from `[TContents]` to `[Integer]`
- Fix `Serializers::Zip#load` `@return` from `[TContents]` to `[Nodes::Node]`
- Fix `Comparable#==` `@return` to mention all four equality checks
- Fix `Stringifyable#as_word` `@raise` condition (raises on non-root non-terminal, not on root)
- Fix `Nodes::Raw#add` `@note` to accurately describe pop-per-recursion behavior