### PR TITLE
Add deprecation warning on `Container#compress` call after already compressed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Handle tmp dir compatibility issues ([#104][github_pull_104]) by [@gonzedge][github_user_gonzedge]
   - Replace hardcoded `/tmp` with `Dir.tmpdir` in `Properties`
   - Rename `Serializers::Zip#path{,_with_random_prefix}` to better communicate intent
+- Deprecate calling `compress` on an already-compressed trie ([#120][github_pull_120])
+  by [@gonzedge][github_user_gonzedge]
 
 #### Minor
 
@@ -1420,6 +1422,7 @@ Most of these help with the gem's overall performance.
 [github_pull_117]: https://github.com/gonzedge/rambling-trie/pull/117
 [github_pull_118]: https://github.com/gonzedge/rambling-trie/pull/118
 [github_pull_119]: https://github.com/gonzedge/rambling-trie/pull/119
+[github_pull_120]: https://github.com/gonzedge/rambling-trie/pull/120
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/doc/20260411-claude-code-review.md
+++ b/doc/20260411-claude-code-review.md
@@ -39,7 +39,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 27 | **Low**      | `container.rb:133`               | `each` returns a `Node`, not `self`, when a block is given         | [#105][gh_105]                    |
 | [x]  | 28 | **Low**      | `configuration/properties.rb:42` | Hardcoded `/tmp` — not portable across platforms                   | [#104][gh_104]                    |
 | [x]  | 29 | **Low**      | `serializers/yaml.rb:26`         | `aliases: true` enables billion-laughs YAML memory attack          | [#99][gh_99]                      |
-| [ ]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` after compressed — inconsistent identity |                                   |
+| [x]  | 30 | **Low**      | `container.rb:61`                | `compress` returns `self` after compressed — inconsistent identity | [#120][gh_120]                    |
 
 ---
 
@@ -738,4 +738,5 @@ no work is needed). `compress!` is the correct mutation path.
 [gh_108]: https://github.com/gonzedge/rambling-trie/pull/108
 [gh_113]: https://github.com/gonzedge/rambling-trie/pull/113
 [gh_114]: https://github.com/gonzedge/rambling-trie/pull/114
+[gh_120]: https://github.com/gonzedge/rambling-trie/pull/120
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/doc/20260418-claude-code-review.md
+++ b/doc/20260418-claude-code-review.md
@@ -23,7 +23,7 @@ Legend: `[x]` fixed · `[ ]` pending · `[-]` skipped / won't fix / not applicab
 | [x]  | 38 | **Medium**   | `lib/rambling/trie/nodes/missing.rb`     | `Missing` inherits abstract `Node` private methods that raise `NotImplementedError` from public API | [#110][gh_110] |
 | [-]  | 39 | **Medium**   | `configuration/provider_collection.rb:112` | `contains?` still has dead `|| raise` after the nil guard above              | [feedback][fb_39] |
 | [x]  | 40 | **Medium**   | `container.rb:211-222`                   | `words_within_root` returns wrong type (a `Range`) when block given and phrase is empty | [#111][gh_111] |
-| [ ]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) |                |
+| [x]  | 30 | **Low**      | `container.rb:68-72`                     | `compress` returns `self` after compressed — inconsistent identity (carried from prior review) | [#120][gh_120] |
 | [x]  | 41 | **Low**      | `nodes/compressed.rb:25`                 | `add _, _ = nil` uses two identical `_` parameters — legal but confusing     | [#116][gh_116] |
 | [-]  | 42 | **Low**      | multiple files (`trie.rb:46,63`; `nodes/raw.rb:34`; `nodes/compressed.rb:38,44,54,65,73,79,94,107`; `serializers/zip.rb:38,59`; `container.rb:225`) | Bare `|| raise` produces uninformative `RuntimeError` with no message | [feedback][fb_42] |
 | [x]  | 43 | **Low**      | `lib/rambling/trie/nodes/node.rb:38-46`  | Default `children_tree = {}` arg creates fresh hash per call but signals shared-hash ownership with caller | [#118][gh_118] |
@@ -683,4 +683,6 @@ docstring:
 [gh_116]: https://github.com/gonzedge/rambling-trie/pull/116
 [gh_117]: https://github.com/gonzedge/rambling-trie/pull/117
 [gh_118]: https://github.com/gonzedge/rambling-trie/pull/118
+[gh_119]: https://github.com/gonzedge/rambling-trie/pull/119
+[gh_120]: https://github.com/gonzedge/rambling-trie/pull/120
 [gh_user_gonzedge]: https://github.com/gonzedge

--- a/lib/rambling/trie/container.rb
+++ b/lib/rambling/trie/container.rb
@@ -66,10 +66,18 @@ module Rambling
       end
 
       # Compresses the existing trie using redundant node elimination. Returns a new trie with the compressed root.
-      # @return [Container] A new {Container} with the {Nodes::Compressed Compressed} root node
-      #   or self if the trie has already been compressed.
+      # @return [Container] A new {Container} with the {Nodes::Compressed Compressed} root node.
+      # @deprecated Calling {#compress} on an already-compressed trie is deprecated and will raise
+      #   {InvalidOperation} in the next major version. Use {#compressed?} to guard if needed.
       def compress
-        return self if root.compressed?
+        if root.compressed?
+          warn <<~WARN.chomp.tr("\n", ' ')
+            [DEPRECATED] Calling `compress` on an already-compressed trie is deprecated
+            and will raise `InvalidOperation` in the next major version.
+            Called from #{caller_locations(1, 1)&.first}
+          WARN
+          return Rambling::Trie::Container.new root, compressor
+        end
 
         Rambling::Trie::Container.new compress_root, compressor
       end

--- a/spec/lib/rambling/trie/container_spec.rb
+++ b/spec/lib/rambling/trie/container_spec.rb
@@ -118,11 +118,26 @@ describe Rambling::Trie::Container do
       expect(compressor).to have_received(:compress).twice
     end
 
-    it 'cannot compress the result' do
-      new_container = container.compress
-      new_container.compress
+    context 'when already compressed' do
+      let(:compressed_container) { container.compress }
 
-      expect(compressor).to have_received(:compress).once
+      it 'emits a deprecation warning' do
+        expect { compressed_container.compress }.to output(%r{deprecated}i).to_stderr
+      end
+
+      it 'returns a new container' do
+        expect(compressed_container.compress).not_to equal compressed_container
+      end
+
+      it 'returns a container with the same root' do
+        expect(compressed_container.compress.root).to equal compressed_container.root
+      end
+
+      it 'does not compress again' do
+        compressed_container.compress
+
+        expect(compressor).to have_received(:compress).once
+      end
     end
   end
 


### PR DESCRIPTION
_Deals with issue no. 30 in [doc/20260411-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260411-claude-code-review.md) and [doc/20260418-claude-code-review.md](/gonzedge/rambling-trie/blob/main/doc/20260418-claude-code-review.md)._

The plan is to raise `InvalidOperation` when attempting to `compress` an already compressed trie, but that is a breaking change. Leaving that to come back to it in a future `3.0.0` version.