### PR TITLE
Allow benchmark scripts to run with ruby `4.0.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@
   by [@gonzedge][github_user_gonzedge]
 - Fix YARD documentation inaccuracies across multiple files ([#119][github_pull_119])
   by [@gonzedge][github_user_gonzedge]
+- Allow benchmark scripts to run with ruby `4.0.x` ([#123][github_pull_123]) by [@gonzedge][github_user_gonzedge]
+  - Adds `benchmark`/`benchmark-ips` to minimal `Gemfile`/`Rakefile` for `Dockerfile.benchmark`
+  - Adds `-n` (`--no-cache`) and `-V` (`--progress=plain`) flags to benchmark scripts
 
 ## 2.6.0 [compare][compare_v2_5_1_and_v2_6_0]
 
@@ -1423,6 +1426,7 @@ Most of these help with the gem's overall performance.
 [github_pull_118]: https://github.com/gonzedge/rambling-trie/pull/118
 [github_pull_119]: https://github.com/gonzedge/rambling-trie/pull/119
 [github_pull_120]: https://github.com/gonzedge/rambling-trie/pull/120
+[github_pull_123]: https://github.com/gonzedge/rambling-trie/pull/123
 [github_user_agate]: https://github.com/agate
 [github_user_as181920]: https://github.com/as181920
 [github_user_godsent]: https://github.com/godsent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,9 @@ Each version argument accepts an optional `@<ruby_version>` suffix:
 ./scripts/benchmark/compare.sh -g <sha1>@3.3.6 <sha2>@3.4.0
 ```
 
+> **Note:** When using `-g` and comparing a git SHA against a release tag, prefix the release version with `v` so
+> git resolves it correctly: `./scripts/benchmark/compare.sh -g <sha> v2.6.0`.
+
 [github_fork]: https://help.github.com/articles/fork-a-repo
 [github_issues_all]: https://github.com/gonzedge/rambling-trie/issues?utf8=%E2%9C%93&q=is%3Aissue
 [github_issues_new]: https://github.com/gonzedge/rambling-trie/issues/new

--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -8,7 +8,11 @@ WORKDIR /usr/rambling-trie
 RUN git init
 
 # Generate benchmark-specific minimal Gemfile
-RUN echo "source 'https://rubygems.org'\n\ngem 'rake'\ngem 'rubyzip'\n" > Gemfile && \
+RUN echo "source 'https://rubygems.org'\n\n" > Gemfile && \
+  echo "gem 'rake'\n" >> Gemfile && \
+  echo "gem 'rubyzip'\n" >> Gemfile && \
+  echo "gem 'benchmark'\n" >> Gemfile && \
+  echo "gem 'benchmark-ips'\n" >> Gemfile && \
   if [ "$FROM_GITHUB" = "false" ]; \
   then echo "gem 'rambling-trie', '=$VERSION'" >> Gemfile; \
   else echo "gem 'rambling-trie', github: 'gonzedge/rambling-trie', ref: '$VERSION'" >> Gemfile; \
@@ -24,6 +28,8 @@ COPY tasks ./tasks
 # Generate minimal Rakefile
 RUN echo "# frozen_string_literal: true\n\n" > Rakefile && \
   echo "require 'rambling-trie'\n" >> Rakefile && \
+  echo "require 'benchmark'\n" >> Rakefile && \
+  echo "require 'benchmark/ips'\n" >> Rakefile && \
   echo "require_relative 'tasks/performance'\n" >> Rakefile && \
   echo "require_relative 'tasks/serialization'\n" >> Rakefile && \
   echo "require_relative 'tasks/ips'\n" >> Rakefile

--- a/scripts/benchmark/compare.sh
+++ b/scripts/benchmark/compare.sh
@@ -5,13 +5,15 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  echo "Usage: $0 [-g] <version1> <version2>"
+  echo "Usage: $0 [-g] [-n] [-V] <version1> <version2>"
   echo ""
   echo "Each version may optionally embed a ruby version as <trie_version>@<ruby_version>."
   echo "If omitted, ruby defaults to 3.3.6."
   echo ""
   echo "Options:"
   echo "  -g   treat versions as git refs (passed to run.sh -g)"
+  echo "  -n   skip docker layer cache (passed to run.sh -n)"
+  echo "  -V   verbose docker build output (passed to run.sh -V)"
   echo ""
   echo "Examples:"
   echo "  # two trie versions, same ruby"
@@ -27,14 +29,18 @@ usage() {
   exit 1
 }
 
-git_flag=""
+extra_flags=""
 
-OPT_STRING="g"
+OPT_STRING="gnV"
 
 while getopts ${OPT_STRING} opt; do
   case ${opt} in
     g)
-      git_flag="-g";;
+      extra_flags="${extra_flags} -g";;
+    n)
+      extra_flags="${extra_flags} -n";;
+    V)
+      extra_flags="${extra_flags} -V";;
   esac
 done
 
@@ -65,14 +71,14 @@ else
 fi
 
 echo "==> Running benchmark for ${version1} (ruby ${ruby1})"
-file1=$(bash "${SCRIPT_DIR}/run.sh" ${git_flag} -v "${version1}@${ruby1}" | tail -1)
+file1=$(bash "${SCRIPT_DIR}/run.sh" ${extra_flags} -v "${version1}@${ruby1}" | tail -1)
 
 echo ""
 echo "==> Running benchmark for ${version2} (ruby ${ruby2})"
-file2=$(bash "${SCRIPT_DIR}/run.sh" ${git_flag} -v "${version2}@${ruby2}" | tail -1)
+file2=$(bash "${SCRIPT_DIR}/run.sh" ${extra_flags} -v "${version2}@${ruby2}" | tail -1)
 
 echo ""
 echo "==> Diff: ${spec1} vs ${spec2}"
-output_file="tmp/${version1}@${ruby1}-vs-${version2}@${ruby2}.benchmark.diff"
+output_file="tmp/${version1}@${ruby1}-vs-${version2}@${ruby2}.benchmark.patch"
 git diff --no-index "${file1}" "${file2}" | tee "${output_file}" || true
 echo "${output_file}"

--- a/scripts/benchmark/run.sh
+++ b/scripts/benchmark/run.sh
@@ -3,10 +3,12 @@
 set -eo pipefail
 
 from_github=false
+no_cache=false
 ruby_version=3.3.6
+verbose=false
 version=latest
 
-OPT_STRING="gv:"
+OPT_STRING="gnv:V"
 
 while getopts ${OPT_STRING} opt; do
   case ${opt} in
@@ -22,8 +24,18 @@ while getopts ${OPT_STRING} opt; do
     g) # use git ref instead of rubygems version
       from_github=true
       echo "from_github set to ${from_github}";;
+    n) # skip docker layer cache
+      no_cache=true
+      echo "no_cache set to ${no_cache}";;
+    V) # verbose docker build output
+      verbose=true
+      echo "verbose set to ${verbose}";;
   esac
 done
+
+docker_build_args=()
+[[ "${no_cache}" == "true" ]] && docker_build_args+=(--no-cache)
+[[ "${verbose}" == "true" ]] && docker_build_args+=(--progress=plain)
 
 echo "Building benchmark image for version=${version}, ruby=${ruby_version}, from_github=${from_github}"
 
@@ -32,7 +44,8 @@ docker build . --file Dockerfile.benchmark \
   --build-arg VERSION=${version} \
   --build-arg FROM_GITHUB=${from_github} \
   --build-arg RUBY_VERSION=${ruby_version} \
-  --tag ${image} && \
+  --tag ${image} \
+  "${docker_build_args[@]}" && \
   echo "Image ${image} built!"
 
 output_file="tmp/${version}@${ruby_version}.benchmark"

--- a/scripts/benchmark/run.sh
+++ b/scripts/benchmark/run.sh
@@ -50,5 +50,5 @@ docker build . --file Dockerfile.benchmark \
 
 output_file="tmp/${version}@${ruby_version}.benchmark"
 echo "Running performance[benchmark] in ${image}"
-docker run -it ${image} bash -c 'bundle exec rake performance[benchmark]' | tee "${output_file}"
+docker run -it ${image} bash -c 'RUBYOPT=-W0 bundle exec rake performance[benchmark]' | tee "${output_file}"
 echo "${output_file}"


### PR DESCRIPTION
This error is currently being shown when trying to run `bundle exec rake performance[benchmark]` within any Ruby 4.x+:

```
Running performance[benchmark] in rambling-trie:benchmark.017e799.ruby-4.0.3
/usr/rambling-trie/tasks/performance/reporters/benchmark.rb:3: warning: benchmark used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add benchmark to your Gemfile or gemspec to fix this error.
rake aborted!
LoadError: cannot load such file -- benchmark (LoadError)
```

I thought I had fixed it in #87 by adding both the `benchmark` and the `irb` gems to the `Gemspec`. Well, turns out the benchmark Dockerfile uses a significantly reduced version, so that change was not enough. None of the additions in #112 made a difference either.

This PR:

1. Adds `benchmark` and `benchmark-ips` to minimal `Gemfile` created within `Dockerfile.benchmark`
2. Require both gems at the top of the generated `Rakefile` so that we fail fast
3. Adds `-n` flag to both `run.sh` and `compare.sh` to allow docker builds for the same gem version / git SHA (`--no-cache`)
4. Adds `-V` flag to both `run.sh` and `compare.sh` to allow verbose output during docker builds (`--progress=plain`)

---

Also:
- Updates `CONTRIBUTING.md` to clarify `-g` flag usage combined with a released gem version
- Suppresses warnings during `Dockerfile.benchmark` runs
- Changes file extension from `.diff` to `.patch`